### PR TITLE
Fix integration loading

### DIFF
--- a/lib/job-iteration.rb
+++ b/lib/job-iteration.rb
@@ -17,14 +17,13 @@ module JobIteration
   def load_integrations
     loaded = nil
     INTEGRATIONS.each do |integration|
-      if loaded
-        raise IntegrationLoadError,
-          "#{loaded} integration has already been loaded, but #{integration} is also available. " \
-          "Iteration will only work with one integration."
-      end
-
       begin
         load_integration(integration)
+        if loaded
+          raise IntegrationLoadError,
+            "#{loaded} integration has already been loaded, but #{integration} is also available. " \
+            "Iteration will only work with one integration."
+        end
         loaded = integration
       rescue LoadError
       end

--- a/test/integration/integrations_test.rb
+++ b/test/integration/integrations_test.rb
@@ -17,6 +17,20 @@ class IntegrationsTest < ActiveSupport::TestCase
     end
   end
 
+  test "successfully loads one (resque) integration" do
+    with_env("ITERATION_DISABLE_AUTOCONFIGURE", nil) do
+      rubby = <<~RUBBY
+        require 'bundler/setup'
+        # Remove sidekiq, only resque will be left
+        $LOAD_PATH.delete_if { |p| p =~ /sidekiq/ }
+        require 'job-iteration'
+      RUBBY
+      _stdout, _stderr, status = run_ruby(rubby)
+
+      assert_equal true, status.success?
+    end
+  end
+
   private
 
   def run_ruby(body)


### PR DESCRIPTION
This fixes apps that had only Resque in their $LOAD_PATH. The bug was due the order of gems in `JobIteration::INTEGRATIONS`.