### PR TITLE
Allow to extend job_should_exit? 

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -120,7 +120,7 @@ module JobIteration
           self.cursor_position = index
         end
 
-        next unless job_should_exit?
+        next unless should_interrupt?
         self.executions -= 1 if executions > 1
         shutdown_and_reenqueue
         return false
@@ -193,12 +193,12 @@ module JobIteration
       logger.info Kernel.format(message, times_interrupted, total_time)
     end
 
-    def job_should_exit?
+    def should_interrupt?
       if ::JobIteration.max_job_runtime && start_time && (Time.now.utc - start_time) > ::JobIteration.max_job_runtime
         return true
       end
 
-      JobIteration.interruption_adapter.call
+      JobIteration.interruption_adapter.call || (respond_to?(:job_should_exit?, true) && job_should_exit?)
     end
   end
 end

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -120,7 +120,7 @@ module JobIteration
           self.cursor_position = index
         end
 
-        next unless should_interrupt?
+        next unless job_should_exit?
         self.executions -= 1 if executions > 1
         shutdown_and_reenqueue
         return false
@@ -193,12 +193,12 @@ module JobIteration
       logger.info Kernel.format(message, times_interrupted, total_time)
     end
 
-    def should_interrupt?
+    def job_should_exit?
       if ::JobIteration.max_job_runtime && start_time && (Time.now.utc - start_time) > ::JobIteration.max_job_runtime
         return true
       end
 
-      JobIteration.interruption_adapter.call || (respond_to?(:job_should_exit?, true) && job_should_exit?)
+      JobIteration.interruption_adapter.call
     end
   end
 end

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -198,7 +198,7 @@ module JobIteration
         return true
       end
 
-      JobIteration.interruption_adapter.call
+      JobIteration.interruption_adapter.call || (defined?(super) && super)
     end
   end
 end

--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -214,11 +214,13 @@ module JobIteration
       end
     end
 
-    class JobShouldExitJob < ActiveJob::Base
+    class ParentJobShouldExitJob < ActiveJob::Base
       def job_should_exit?
         true
       end
+    end
 
+    class JobShouldExitJob < ParentJobShouldExitJob
       include JobIteration::Iteration
 
       cattr_accessor :records_performed, instance_accessor: false
@@ -560,9 +562,8 @@ module JobIteration
       assert_match(/#build_enumerator is expected to return Enumerator object/, error.to_s)
     end
 
-    def test_job_should_exit_job
+    def test_respects_job_should_exit_from_parent_class
       JobShouldExitJob.new.perform_now
-
       assert_equal [0], JobShouldExitJob.records_performed
     end
 


### PR DESCRIPTION
This is needed for apps like Shopify that extend `job_should_exit?` to support interrupting not only by shutdown signals, but also based on different factors (like a flag in database).