### PR TITLE
Only enqueue a job if it wasn't already enqueued

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -144,9 +144,14 @@ module JobIteration
 
       self.already_in_queue = true if respond_to?(:already_in_queue=)
       run_callbacks :shutdown
-      enqueue
+      retry_job unless @enqueued
 
       true
+    end
+
+    def retry_job(*)
+      @enqueued = true
+      super
     end
 
     def adjust_total_time


### PR DESCRIPTION
Fixes #12 

@kirs I applied the necessary changes to avoid the double `enqueue` issue.

Hope this helps 💎 