### PR TITLE
Do not mark as complete when throttled

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -124,7 +124,7 @@ module JobIteration
 
         next unless job_should_exit?
         self.executions -= 1 if executions > 1
-        shutdown_and_reenqueue
+        reenqueue_iteration_job
         return false
       end
 
@@ -137,7 +137,7 @@ module JobIteration
       end
     end
 
-    def shutdown_and_reenqueue
+    def reenqueue_iteration_job
       ActiveSupport::Notifications.instrument("interrupted.iteration", iteration_instrumentation_tags)
       logger.info "[JobIteration::Iteration] Interrupting and re-enqueueing the job cursor_position=#{cursor_position}"
 
@@ -145,10 +145,7 @@ module JobIteration
       self.times_interrupted += 1
 
       self.already_in_queue = true if respond_to?(:already_in_queue=)
-      run_callbacks :shutdown
       retry_job unless @retried
-
-      true
     end
 
     def retry_job(*)

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -102,14 +102,16 @@ module JobIteration
         ActiveSupport::Notifications.instrument("resumed.iteration", iteration_instrumentation_tags)
       end
 
-      catch(:abort) do
-        return unless iterate_with_enumerator(enumerator, arguments)
+      completed = catch(:abort) do
+        iterate_with_enumerator(enumerator, arguments)
       end
 
       run_callbacks :shutdown
-      run_callbacks :complete
 
-      output_interrupt_summary
+      if completed
+        run_callbacks :complete
+        output_interrupt_summary
+      end
     end
 
     def iterate_with_enumerator(enumerator, arguments)

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -146,13 +146,13 @@ module JobIteration
 
       self.already_in_queue = true if respond_to?(:already_in_queue=)
       run_callbacks :shutdown
-      retry_job unless @enqueued
+      retry_job unless @retried
 
       true
     end
 
     def retry_job(*)
-      @enqueued = true
+      @retried = true
       super
     end
 

--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -351,7 +351,7 @@ module JobIteration
       assert cursor
 
       assert_equal 0, ActiveRecordIterationJob.on_complete_called
-      assert_equal 4, ActiveRecordIterationJob.on_shutdown_called
+      assert_equal 2, ActiveRecordIterationJob.on_shutdown_called
     end
 
     def test_activerecord_batches_complete

--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -351,7 +351,7 @@ module JobIteration
       assert cursor
 
       assert_equal 0, ActiveRecordIterationJob.on_complete_called
-      assert_equal 2, ActiveRecordIterationJob.on_shutdown_called
+      assert_equal 4, ActiveRecordIterationJob.on_shutdown_called
     end
 
     def test_activerecord_batches_complete
@@ -537,11 +537,12 @@ module JobIteration
       end
     end
 
-    def test_aborting_in_each_iteration_job
+    def test_aborting_in_each_iteration_job_will_not_execute_on_complete_callback
       push(AbortingActiveRecordIterationJob)
       work_one_job
       assert_equal 2, AbortingActiveRecordIterationJob.records_performed.size
-      assert_equal 1, AbortingActiveRecordIterationJob.on_complete_called
+      assert_equal 0, AbortingActiveRecordIterationJob.on_complete_called
+      assert_equal 1, AbortingActiveRecordIterationJob.on_shutdown_called
     end
 
     def test_aborting_in_batched_job
@@ -549,7 +550,7 @@ module JobIteration
       work_one_job
       assert_equal 2, AbortingBatchActiveRecordIterationJob.records_performed.size
       assert_equal [3, 3], AbortingBatchActiveRecordIterationJob.records_performed.map(&:size)
-      assert_equal 1, AbortingBatchActiveRecordIterationJob.on_complete_called
+      assert_equal 0, AbortingBatchActiveRecordIterationJob.on_complete_called
     end
 
     def test_checks_for_exit_after_iteration


### PR DESCRIPTION
Fixes #17 

Make sure that `on_complete` is only called with the job has been completed.