### PR TITLE
Add each_iteration callback

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -17,6 +17,7 @@ module JobIteration
       define_callbacks :start
       define_callbacks :shutdown
       define_callbacks :complete
+      define_callbacks :each_iteration
     end
 
     module ClassMethods
@@ -34,6 +35,14 @@ module JobIteration
 
       def on_complete(*filters, &blk)
         set_callback(:complete, :after, *filters, &blk)
+      end
+
+      def before_each_iteration(*filters, &blk)
+        set_callback(:each_iteration, :before, *filters, &blk)
+      end
+
+      def after_each_iteration(*filters, &blk)
+        set_callback(:each_iteration, :after, *filters, &blk)
       end
 
       def supports_interruption?
@@ -123,7 +132,9 @@ module JobIteration
       arguments = arguments.dup.freeze
       enumerator.each do |iteration, index|
         record_unit_of_work do
-          each_iteration(iteration, *arguments)
+          run_callbacks(:each_iteration) do
+            each_iteration(iteration, *arguments)
+          end
           self.cursor_position = index
         end
 


### PR DESCRIPTION
This PR add callbacks around each iteration. The intention is for concerns to use this to inject behaviours around iterations.

The first use-case I see for this is to clear the ActiveRecord query cache between iterations of the `BackgroundQueue::LockQueue` concern, because not doing so may change the result of each iteration of a job compared to running multiple jobs.