### PR TITLE
iteration: don't allow double-retrying a job

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -73,8 +73,8 @@ module JobIteration
     end
 
     def retry_job(*)
+      super unless @retried
       @retried = true
-      super
     end
 
     private
@@ -150,7 +150,7 @@ module JobIteration
       self.times_interrupted += 1
 
       self.already_in_queue = true if respond_to?(:already_in_queue=)
-      retry_job unless @retried
+      retry_job
     end
 
     def adjust_total_time

--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -222,10 +222,6 @@ module JobIteration
       def each_iteration(*)
       end
 
-      def job_should_exit?
-        true
-      end
-
       on_shutdown do
         retry_job
       end
@@ -363,6 +359,8 @@ module JobIteration
     end
 
     def test_retry_job_from_shutdown_hook_doesnt_retry_job
+      mark_job_worker_as_interrupted
+
       push(ReenqueuingIterationJob)
       work_one_job
       assert_jobs_in_queue(1)


### PR DESCRIPTION
Addresses https://github.com/Shopify/job-iteration/issues/26

If a job ends up calling `retry_job` in its `on_shutdown` hook either directly or indirectly (through a retry extension that re-enqueues on execution error) _and_ `should_job_exit?` is true (e.g. exceeding `Iteration.max_job_runtime`)—then the job will get double-enqueued. This can cause exponential job growth.

**Example.** Imagine that `Iteration.max_job_runtime = 5.minutes` and a job will take 2 hours to complete. This means there's a total of `(2 * 60) / 5 = 24` interruptions. On each interruption, every job will spawn _two_ jobs. This will lead to a total of `2^24 = 16 million` jobs in just a span of about 2 hours.

**Discussion.** `super unless @retried` seems fairly heavy-handed, and I worry about how it'll interface with downstream dependencies. Likely, bumping this in `shopify/shopify`'s test suite will reveal problems with this approach. That said, I can't think of a legit use-case for calling `retry_job` twice in the same context. This seems like a sensible thing to guard against and we've missed `unless @retried` repeatedly. That said, I'd be surprised if @kirs hasn't considered porting this into the monkey-patch since he's suffered the most pain with these conditionals for double-reenqueue. An alternative would be to try to teach retry logic about iteration, but that almost feels more ugly.
