### PR TITLE
Better #each_iteration argument names

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -121,9 +121,9 @@ module JobIteration
 
     def iterate_with_enumerator(enumerator, arguments)
       arguments = arguments.dup.freeze
-      enumerator.each do |iteration, index|
+      enumerator.each do |object_from_enumerator, index|
         record_unit_of_work do
-          each_iteration(iteration, *arguments)
+          each_iteration(object_from_enumerator, *arguments)
           self.cursor_position = index
         end
 


### PR DESCRIPTION
This is a pretty cosmetic change. Nonetheless, while debugging, it's easy to assume that `iteration` is some sort of index, or numeric value, rather than the actual object returned by the enumerator itself. 

If this is deemed to be too trivial to warrant a change, that's okay :)