### PR TITLE
remove supports_interruption?

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -36,10 +36,6 @@ module JobIteration
         set_callback(:complete, :after, *filters, &blk)
       end
 
-      def supports_interruption?
-        true
-      end
-
       private
 
       def ban_perform_definition


### PR DESCRIPTION
In `Shopify/shopify` we no longer support the method `supports_interruption?`

PR in core https://github.com/Shopify/shopify/pull/197574

We are simplifying the Job model in core and removing extra configurations.

@Shopify/job-patterns

