### PR TITLE
Make sure `cursor` is a keyword argument

### DIFF
--- a/job-iteration.gemspec
+++ b/job-iteration.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |spec|
 
   spec.metadata["changelog_uri"] = "https://github.com/Shopify/job-iteration/blob/master/CHANGELOG.md"
 
+  spec.add_development_dependency("activerecord")
   spec.add_dependency("activejob", ">= 5.2")
 end

--- a/test/unit/iteration_test.rb
+++ b/test/unit/iteration_test.rb
@@ -3,7 +3,78 @@
 require "test_helper"
 
 class JobIterationTest < IterationUnitTest
+  class JobWithNoMethods < ActiveJob::Base
+    include JobIteration::Iteration
+  end
+
+  class JobWithRightMethods < ActiveJob::Base
+    include JobIteration::Iteration
+    def build_enumerator(_params, cursor:)
+      enumerator_builder.build_times_enumerator(2, cursor: cursor)
+    end
+
+    def each_iteration(*)
+    end
+  end
+
+  class JobWithRightMethodsButMissingCursorKeywordArgument < ActiveJob::Base
+    include JobIteration::Iteration
+    def build_enumerator(params, cursor)
+      enumerator_builder.active_record_on_records(
+        Product.where(id: params[:id]),
+        cursor: cursor,
+      )
+    end
+
+    def each_iteration(product, params)
+    end
+  end
+
+  class JobWithRightMethodsUsingSplatInTheArguments < ActiveJob::Base
+    include JobIteration::Iteration
+    def build_enumerator(*)
+    end
+
+    def each_iteration(*)
+    end
+  end
+
+  def test_jobs_that_define_build_enumerator_and_each_iteration_will_not_raise
+    push(JobWithRightMethods, 'walrus' => 'best')
+    work_one_job
+  end
+
+  def test_jobs_that_pass_splat_argument_to_build_enumerator_will_not_raise
+    push(JobWithRightMethodsUsingSplatInTheArguments, {})
+    work_one_job
+  end
+
+  def test_jobs_that_do_not_define_build_enumerator_or_each_iteration_raises
+    push(JobWithNoMethods)
+    assert_raises(ArgumentError) do
+      work_one_job
+    end
+  end
+
+  def test_jobs_that_defines_methods_but_do_not_declare_cursor_as_keyword_argument_raises
+    push(JobWithRightMethodsButMissingCursorKeywordArgument, id: 1)
+    assert_raises(ArgumentError) do
+      work_one_job
+    end
+  end
+
   def test_that_it_has_a_version_number
     refute_nil(::JobIteration::VERSION)
+  end
+
+  private
+
+  def push(job, *args)
+    job.perform_later(*args)
+  end
+
+  def work_one_job
+    job = ActiveJob::Base.queue_adapter.enqueued_jobs.pop
+    ActiveJob::Base.execute(job)
   end
 end


### PR DESCRIPTION
We found cases of people using `cursor` argument, not as a keyword argument.

This can lead to unexpected behaviour.

[Discourse ticket](https://discourse.shopify.io/t/maintenancetask-throttled-restarts-from-the-beginning/3490)

This change introduces an extra level of checking so when running the
job, we make sure the signature of build_enumerator has the `cursor` keyword
argument

@Shopify/job-patterns