### PR TITLE
add case for validation of cursor argument to use default values

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -228,7 +228,7 @@ module JobIteration
 
       parameters.each do |parameter_type, parameter_name|
         next unless parameter_name == :cursor
-        return true if parameter_type == :keyreq
+        return true if [:keyreq, :key].include?(parameter_type)
       end
       false
     end

--- a/test/unit/iteration_test.rb
+++ b/test/unit/iteration_test.rb
@@ -39,6 +39,15 @@ class JobIterationTest < IterationUnitTest
     end
   end
 
+  class JobWithRightMethodsUsingDefaultKeywordArgument < ActiveJob::Base
+    include JobIteration::Iteration
+    def build_enumerator(params, cursor: nil)
+    end
+
+    def each_iteration(*)
+    end
+  end
+
   def test_jobs_that_define_build_enumerator_and_each_iteration_will_not_raise
     push(JobWithRightMethods, 'walrus' => 'best')
     work_one_job
@@ -46,6 +55,11 @@ class JobIterationTest < IterationUnitTest
 
   def test_jobs_that_pass_splat_argument_to_build_enumerator_will_not_raise
     push(JobWithRightMethodsUsingSplatInTheArguments, {})
+    work_one_job
+  end
+
+  def test_jobs_that_pass_default_keyword_argument_to_build_enumerator_will_not_raise
+    push(JobWithRightMethodsUsingDefaultKeywordArgument, {})
     work_one_job
   end
 


### PR DESCRIPTION
When updating the gem in `Shopify/shopify` repo https://github.com/Shopify/shopify/pull/208463 there was some failing test.

The failing tests were because some people do not use the `cursor` argument and they used default values for it.

`def build_enumerator(params, cursor: nil)`

That is a legitimate use case and we should support that within the library.

The changes in this PR allow people to define there was using default keyword arguments.

@Shopify/job-patterns