### PR TITLE
Fix count_rows_in_file for ruby 2.6.3

### DIFF
--- a/lib/job-iteration/csv_enumerator.rb
+++ b/lib/job-iteration/csv_enumerator.rb
@@ -49,6 +49,7 @@ module JobIteration
     private
 
     def count_rows_in_file
+      # TODO: Remove rescue for NoMethodError when Ruby 2.6 is no longer supported.
       begin
         filepath = @csv.path
       rescue NoMethodError
@@ -56,7 +57,7 @@ module JobIteration
       end
 
       # Behaviour of CSV#path changed in Ruby 2.6.3 (returns nil instead of raising NoMethodError)
-      return if filepath.nil?
+      return unless filepath
 
       count = %x(wc -l < #{filepath}).strip.to_i
       count -= 1 if @csv.headers

--- a/lib/job-iteration/csv_enumerator.rb
+++ b/lib/job-iteration/csv_enumerator.rb
@@ -55,6 +55,9 @@ module JobIteration
         return
       end
 
+      # Behaviour of CSV#path changed in Ruby 2.6.3 (returns nil instead of raising NoMethodError)
+      return if filepath.nil?
+
       count = %x(wc -l < #{filepath}).strip.to_i
       count -= 1 if @csv.headers
       count

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.1.1"
+  VERSION = "1.1.2"
 end


### PR DESCRIPTION
[`CSV#path`](https://ruby-doc.org/stdlib-2.6.3/libdoc/csv/rdoc/CSV.html#method-i-path) was added to Ruby 2.6.3 and returns `nil` when the path of the CSV does not exist (instead of raising a `NoMethodError`). Ran into an issue where this method was returning `-1` in 2.6.3 when the path was `nil`.

Also bumps the patch version.
