### PR TITLE
Refactor the class method validation logic

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -47,6 +47,7 @@ module JobIteration
       super
       self.times_interrupted = 0
       self.total_time = 0.0
+      assert_implements_methods!
     end
 
     def serialize # @private
@@ -80,8 +81,6 @@ module JobIteration
     end
 
     def interruptible_perform(*arguments)
-      assert_implements_methods!
-
       self.start_time = Time.now.utc
 
       enumerator = nil

--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -171,6 +171,14 @@ module JobIteration
       end
     end
 
+    class CustomEnumerationJob < SimpleIterationJob
+      def build_enumerator(_params, cursor:)
+      end
+
+      def each_iteration(*)
+      end
+    end
+
     class MultipleColumnsActiveRecordIterationJob < SimpleIterationJob
       def build_enumerator(cursor:)
         enumerator_builder.active_record_on_records(
@@ -295,17 +303,15 @@ module JobIteration
     end
 
     def test_each_iteration_method_missing
-      push(MissingEachIterationJob)
       error = assert_raises(ArgumentError) do
-        work_one_job
+        push(MissingEachIterationJob)
       end
       assert_match(/Iteration job \(\S+\) must implement #each_iteration/, error.to_s)
     end
 
     def test_build_enumerator_method_missing
-      push(MissingBuildEnumeratorJob)
       error = assert_raises(ArgumentError) do
-        work_one_job
+        push(MissingBuildEnumeratorJob)
       end
       assert_match(/Iteration job \(\S+\) must implement #build_enumerator/, error.to_s)
     end
@@ -641,7 +647,7 @@ module JobIteration
       original_builder = JobIteration.enumerator_builder
       JobIteration.enumerator_builder = CustomEnumBuilder
 
-      builder_instance = SimpleIterationJob.new.send(:enumerator_builder)
+      builder_instance = CustomEnumerationJob.new.send(:enumerator_builder)
       assert_instance_of(CustomEnumBuilder, builder_instance)
     ensure
       JobIteration.enumerator_builder = original_builder

--- a/test/unit/iteration_test.rb
+++ b/test/unit/iteration_test.rb
@@ -64,16 +64,14 @@ class JobIterationTest < IterationUnitTest
   end
 
   def test_jobs_that_do_not_define_build_enumerator_or_each_iteration_raises
-    push(JobWithNoMethods)
     assert_raises(ArgumentError) do
-      work_one_job
+      push(JobWithNoMethods)
     end
   end
 
   def test_jobs_that_defines_methods_but_do_not_declare_cursor_as_keyword_argument_raises
-    push(JobWithRightMethodsButMissingCursorKeywordArgument, id: 1)
     assert_raises(ArgumentError) do
-      work_one_job
+      push(JobWithRightMethodsButMissingCursorKeywordArgument, id: 1)
     end
   end
 


### PR DESCRIPTION
This is in regards to - https://github.com/Shopify/job-iteration/issues/37

This PR moves the method signature checks (i.e `assert_implements_methods!`) to the job initialization step.

This method is really looking at definition level stuff i.e whether the
job class has the necessary methods and the method declarations are
correct. As such, I think having this sort of check in the constructor
makes more sense.
This also updates all the tests accordingly.

If this isn't the case/there's a case for not having it in the
constructor we can just use a boolean to not re-check the signatures on
every invocation of `perform`.