### PR TITLE
allow to setup logger for JobIteration

### DIFF
--- a/lib/job-iteration.rb
+++ b/lib/job-iteration.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+require "active_job"
 require_relative "./job-iteration/version"
 require_relative "./job-iteration/enumerator_builder"
 require_relative "./job-iteration/iteration"
@@ -19,6 +19,9 @@ module JobIteration
   # This setting will make it to always interrupt a job after it's been iterating for 5 minutes.
   # Defaults to nil which means that jobs will not be interrupted except on termination signal.
   attr_accessor :max_job_runtime
+
+  attr_accessor :logger
+  self.logger = ActiveJob::Base.logger
 
   # Used internally for hooking into job processing frameworks like Sidekiq and Resque.
   attr_accessor :interruption_adapter

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -89,7 +89,7 @@ module JobIteration
       end
 
       unless enumerator
-        logger.info("[JobIteration::Iteration] `build_enumerator` returned nil. " \
+        JobIteration.logger.info("[JobIteration::Iteration] `build_enumerator` returned nil. " \
           "Skipping the job.")
         return
       end
@@ -139,7 +139,8 @@ module JobIteration
 
     def reenqueue_iteration_job
       ActiveSupport::Notifications.instrument("interrupted.iteration", iteration_instrumentation_tags)
-      logger.info("[JobIteration::Iteration] Interrupting and re-enqueueing the job cursor_position=#{cursor_position}")
+      JobIteration.logger.info("[JobIteration::Iteration] Interrupting and re-enqueueing the job "\
+        "cursor_position=#{cursor_position}")
 
       adjust_total_time
       self.times_interrupted += 1
@@ -195,7 +196,7 @@ module JobIteration
       adjust_total_time
 
       message = "[JobIteration::Iteration] Completed iterating. times_interrupted=%d total_time=%.3f"
-      logger.info(Kernel.format(message, times_interrupted, total_time))
+      JobIteration.logger.info(Kernel.format(message, times_interrupted, total_time))
     end
 
     def job_should_exit?

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -73,9 +73,9 @@ DatabaseCleaner.strategy = :truncation
 
 module LoggingHelpers
   def assert_logged(message)
-    old_logger = ActiveJob::Base.logger
+    old_logger = JobIteration.logger
     log = StringIO.new
-    ActiveJob::Base.logger = Logger.new(log)
+    JobIteration.logger = Logger.new(log)
 
     begin
       yield
@@ -83,12 +83,12 @@ module LoggingHelpers
       log.rewind
       assert_match(message, log.read)
     ensure
-      ActiveJob::Base.logger = old_logger
+      JobIteration.logger = old_logger
     end
   end
 end
 
-ActiveJob::Base.logger = Logger.new(IO::NULL)
+JobIteration.logger = Logger.new(IO::NULL)
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
Allow users of the gem to setup JobIteration logger 

This issue came from here https://discourse.shopify.io/t/using-rails-logger-in-job-iteration-gem-vs-logger-helper/4299