### PR TITLE
Remove lock_queue_enumerator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gemspec
 gem 'sidekiq'
 gem 'resque'
 
-gem 'mysql2', '~> 0.4.4'
+gem 'mysql2', '~> 0.5'
 gem 'globalid'
 gem 'i18n'
 gem 'redis'

--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -61,16 +61,6 @@ module JobIteration
       wrap(self, enumerable.each_with_index.drop(drop).to_enum { enumerable.size })
     end
 
-    # Builds Enumerator from a lock queue instance that belongs to a job.
-    # The helper is only to be used from jobs that use LockQueue module.
-    def build_lock_queue_enumerator(lock_queue, at_most_once:)
-      unless lock_queue.is_a?(BackgroundQueue::LockQueue::RedisQueue) ||
-          lock_queue.is_a?(BackgroundQueue::LockQueue::RolloutRedisQueue)
-        raise ArgumentError, "an argument to #build_lock_queue_enumerator must be a LockQueue"
-      end
-      wrap(self, BackgroundQueue::LockQueueEnumerator.new(lock_queue, at_most_once: at_most_once).to_enum)
-    end
-
     # Builds Enumerator from Active Record Relation. Each Enumerator tick moves the cursor one row forward.
     #
     # +columns:+ argument is used to build the actual query for iteration. +columns+: defaults to primary key:


### PR DESCRIPTION
Removing `build_lock_queue_enumerator` looks like we forgot to remove this enumerator.  This enumerator is very specific for Shopify and should be in the library.

We already have this enumerator in the Shopify repo anyway https://github.com/Shopify/shopify/blob/2cfab7e4550f9b3194a29620a467e078011f7d65/eagerlib/background_queue/enumerator_builder.rb#L32

@Shopify/job-patterns