### PR TITLE
Add missing `do` keyword for Enumerator.new

### DIFF
--- a/guides/custom-enumerator.md
+++ b/guides/custom-enumerator.md
@@ -8,7 +8,7 @@ class ListJob < ActiveJob::Base
 
   def build_enumerator(*)
     @redis = Redis.new
-    Enumerator.new |yielder|
+    Enumerator.new do |yielder|
       yielder.yield @redis.lpop(key), nil
     end
   end


### PR DESCRIPTION
Found a minor typo in the docs for a custom enumerator - `Enumerator.new` needs a `do` before the block begins.