### PR TITLE
Optional `sorbet-runtime` support for `JobIteration::Iteration` interface validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,6 @@ gem 'mocha'
 gem 'rubocop', '~> 0.77.0'
 gem 'yard'
 gem 'rake'
+
+# for unit testing optional sorbet support
+gem 'sorbet-runtime'

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -176,7 +176,7 @@ module JobIteration
       end
 
       if respond_to?(:build_enumerator, true)
-        parameters = method(:build_enumerator).parameters
+        parameters = method_parameters(:build_enumerator)
         unless valid_cursor_parameter?(parameters)
           raise ArgumentError, "Iteration job (#{self.class}) #build_enumerator " \
           "expects the keyword argument `cursor`"
@@ -185,6 +185,17 @@ module JobIteration
         raise ArgumentError, "Iteration job (#{self.class}) must implement #build_enumerator " \
           "to provide a collection to iterate"
       end
+    end
+
+    def method_parameters(method_name)
+      method = method(method_name)
+
+      if defined?(T::Private::Methods)
+        signature = T::Private::Methods.signature_for_method(method)
+        method = signature.method if signature
+      end
+
+      method.parameters
     end
 
     def iteration_instrumentation_tags


### PR DESCRIPTION
Methods that have Sorbet signatures are wrapped by `sorbet-runtime` so that they can be type-checked for correct params/return-value at runtime. However, that wrapper does not and cannot relay the whole information about the original method like `arity` or `parameters`. (Ref: sorbet/sorbet#2643)

The workaround is to access the original method from the signature if we detect Sorbet is activated and the method in question has a signature.

This PR abstracts the method parameter extraction into a separate method in order to carry out that workaround and adds a test to ensure that interface validation works even when the interface methods are wrapped by Sorbet.