### PR TITLE
Add a fallback for system_line_count to allow CSV objects that represent files being streamed

### DIFF
--- a/test/unit/csv_enumerator_test.rb
+++ b/test/unit/csv_enumerator_test.rb
@@ -116,6 +116,18 @@ module JobIteration
       assert_equal 6, enum.size
     end
 
+    test "#rows work even if system_line_count returns 0" do
+      JobIteration::CsvEnumerator.any_instance.stubs(:system_line_count).returns(0)
+      enum = build_enumerator(open_csv).rows(cursor: 0)
+      assert_equal 11, enum.size
+    end
+
+    test "#batches work even if system_line_count returns 0" do
+      JobIteration::CsvEnumerator.any_instance.stubs(:system_line_count).returns(0)
+      enum = build_enumerator(open_csv).batches(batch_size: 2, cursor: 5)
+      assert_equal 6, enum.size
+    end
+
     private
 
     def build_enumerator(csv)


### PR DESCRIPTION
Hey everyone, I'm preparing to run a somewhat big migration involving ~1.6M records, and would like to do it via a streamed CSV file. Currently, CsvEnumerator is almost perfect except it relies on a system call to `wc` which doesn't work in my case.

This PR adds a fallback method using `CSV.foreach.count` to avoid loading up the entire file at once.