### PR TITLE
Log when enumerator has nothing to iterate

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -116,8 +116,10 @@ module JobIteration
 
     def iterate_with_enumerator(enumerator, arguments)
       arguments = arguments.dup.freeze
+      found_record = false
       enumerator.each do |object_from_enumerator, index|
         record_unit_of_work do
+          found_record = true
           each_iteration(object_from_enumerator, *arguments)
           self.cursor_position = index
         end
@@ -127,6 +129,11 @@ module JobIteration
         reenqueue_iteration_job
         return false
       end
+
+      logger.info(
+        "[JobIteration::Iteration] Enumerator found nothing to iterate! " \
+        "(times_interrupted: #{times_interrupted}, cursor_position: #{cursor_position})"
+      ) unless found_record
 
       true
     end

--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -585,6 +585,15 @@ module JobIteration
       end
     end
 
+    def test_log_no_iterations
+      Product.delete_all
+      push(ActiveRecordIterationJob)
+
+      assert_logged(%([JobIteration::Iteration] Enumerator found nothing to iterate!)) do
+        work_one_job
+      end
+    end
+
     def test_aborting_in_each_iteration_job_will_execute_on_complete_callback
       push(AbortingActiveRecordIterationJob)
       work_one_job


### PR DESCRIPTION
If an Enumerator is built and has nothing to iterate, it can be confusing for developers.  This is particularly true with ActiveRecord enumerators, where developers can be tripped up by default scopes excluding records they don't realize will be excluded.  This PR adds a log message if we attempt to iterate an enumerator with no records to hopefully hint to developers that their enumerator did not actually return anything to help them pinpoint the source of their problem.