### PR TITLE
Adjust logging format when there is nothing to iterate

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -132,7 +132,7 @@ module JobIteration
 
       logger.info(
         "[JobIteration::Iteration] Enumerator found nothing to iterate! " \
-        "(times_interrupted: #{times_interrupted}, cursor_position: #{cursor_position})"
+        "times_interrupted=#{times_interrupted} cursor_position=#{cursor_position}"
       ) unless found_record
 
       true


### PR DESCRIPTION
This PR adjusts the formatting of the params included in the log when an enumerator has nothing to iterate to make those parameters more easily searchable