### PR TITLE
Add allowed_push_host to gemspec

### DIFF
--- a/job-iteration.gemspec
+++ b/job-iteration.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = %w(lib)
 
   spec.metadata["changelog_uri"] = "https://github.com/Shopify/job-iteration/blob/master/CHANGELOG.md"
+  spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.add_development_dependency("activerecord")
   spec.add_dependency("activejob", ">= 5.2")


### PR DESCRIPTION
I was trying to release a new version of the gem and shipit failed due to: 
`Can't release the gem: spec.metadata['allowed_push_host'] must be defined.`
https://shipit.shopify.io/shopify/job-iteration/rubygems/deploys/995956

Setting the `allowed_puh_host` is a new requirement from Shipit https://github.com/Shopify/shipit-engine/pull/1037

Since this is a public gem and we release to RubyGems I added the necessary values.

@Shopify/job-patterns
