### PR TITLE
Test against Ruby 2.7 and fix a couple warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ services:
   - redis-server
 language: ruby
 rvm:
-  - 2.5.5
-  - 2.6.2
+  - 2.5
+  - 2.6
+  - 2.7
 before_install:
   - mysql -e 'CREATE DATABASE job_iteration_test;'
 script:
@@ -14,4 +15,5 @@ script:
 
 gemfile:
   - 'gemfiles/rails_5_2.gemfile'
+  - 'gemfiles/rails_6_0.gemfile'
   - 'gemfiles/rails_edge.gemfile'

--- a/dev.yml
+++ b/dev.yml
@@ -7,7 +7,7 @@ up:
     - mysql-client:
         or:        [mysql@5.7]
   - ruby:
-      version: 2.6.2
+      version: 2.6.5
   - railgun
   - bundler
   - custom:

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+eval_gemfile '../Gemfile'
+
+gem 'activejob', '~> 6.0.0'
+gem 'activerecord', '~> 6.0.0'

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -69,7 +69,7 @@ module JobIteration
       interruptible_perform(*params)
     end
 
-    def retry_job(*)
+    def retry_job(*, **)
       super unless defined?(@retried) && @retried
       @retried = true
     end

--- a/test/unit/csv_enumerator_test.rb
+++ b/test/unit/csv_enumerator_test.rb
@@ -112,7 +112,7 @@ module JobIteration
     end
 
     def open_csv(options = {})
-      CSV.open(sample_csv_with_headers, { converters: :integer, headers: true }.merge(options))
+      CSV.open(sample_csv_with_headers, converters: :integer, headers: true, **options)
     end
   end
 end


### PR DESCRIPTION
Should fix:

```
DEPRECATION WARNING: /tmp/bundle/ruby/2.7.0/gems/job-iteration-1.1.6/lib/job-iteration/iteration.rb:73: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
eagerlib/background_queue/job.rb:258: warning: The called method `retry_job' is defined here
 (called from retry_job at /tmp/bundle/ruby/2.7.0/gems/job-iteration-1.1.6/lib/job-iteration/iteration.rb:73)
```