### PR TITLE
prototype wrapping of query execution for AR cursor

### DIFF
--- a/lib/job-iteration/active_record_enumerator.rb
+++ b/lib/job-iteration/active_record_enumerator.rb
@@ -6,11 +6,12 @@ module JobIteration
   class ActiveRecordEnumerator
     SQL_DATETIME_WITH_NSEC = "%Y-%m-%d %H:%M:%S.%N"
 
-    def initialize(relation, columns: nil, batch_size: 100, cursor: nil)
+    def initialize(relation, columns: nil, batch_size: 100, cursor: nil, around_query: nil)
       @relation = relation
       @batch_size = batch_size
       @columns = Array(columns || "#{relation.table_name}.#{relation.primary_key}")
       @cursor = cursor
+      @around_query = around_query
     end
 
     def records
@@ -48,7 +49,7 @@ module JobIteration
     end
 
     def finder_cursor
-      JobIteration::ActiveRecordCursor.new(@relation, @columns, @cursor)
+      JobIteration::ActiveRecordCursor.new(@relation, @columns, @cursor, @around_query)
     end
 
     def column_value(record, attribute)


### PR DESCRIPTION
hey @kirs @byroot i'm doing a prototype here, no real intentions of merging, any comments welcome. I am doing this for a personal project.

here's the context: I have a vanilla rails app and I'm trying to use multiple connections within the same job. I am using rails' [connected_to](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionHandling.html#method-i-connected_to) block mechanism.

I am running into a problem where I switch connections during each_iteration, which makes the job finish after the first batch is done. It seems that AR switches the default to connection to whatever `connected_to` block was called last.

In any case, this is an attempt to make it possible to pass a block around AR enumerator builder, so I can wrap the query execution in the appropriate connected_to block.