### PR TITLE
Add warning about custom enumerator yields

### DIFF
--- a/guides/custom-enumerator.md
+++ b/guides/custom-enumerator.md
@@ -72,3 +72,5 @@ end
 ```
 
 We recommend that you read the implementation of the other enumerators that come with the library (`CsvEnumerator`, `ActiveRecordEnumerator`) to gain a better understanding of building Enumerator objects.
+
+Code that is written after the `yield` in a custom enumerator is not guaranteed to execute. In the case that a job is forced to exit ie `job_should_exit?` is true, then the job is re-enqueued during the yield and the rest of the code in the enumerator does not run. You can follow that logic [here](https://github.com/Shopify/job-iteration/blob/9641f455b9126efff2214692c0bef423e0d12c39/lib/job-iteration/iteration.rb#L128-L131).


### PR DESCRIPTION
This ended up causing a bug in our code because a custom enumerator thought that code after the `yield` was guaranteed. This puts a warning to make sure developers are aware of this issue.