### PR TITLE
Call `super` in `method_added`

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -22,6 +22,7 @@ module JobIteration
     module ClassMethods
       def method_added(method_name)
         ban_perform_definition if method_name.to_sym == :perform
+        super
       end
 
       def on_start(*filters, &blk)


### PR DESCRIPTION
The `JobIteration::Iteration` module is not being a good citizen by not calling `super` in the `method_added` hook it is registering. This prevents other modules that might have registered `method_added` hooks from receiving the callback. For example, Sorbet runtime does this, and [`JobIteration::Iteration` breaks its functionality][1].

[1]: https://discourse.shopify.io/t/you-called-sig-twice-without-declaring-a-method-inbetween/12595/2?u=ufuk.kayserilioglu