### PR TITLE
Account for drop in enumerable size

### DIFF
--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -59,7 +59,7 @@ module JobIteration
           cursor + 1
         end
 
-      wrap(self, enumerable.each_with_index.drop(drop).to_enum { enumerable.size })
+      wrap(self, enumerable.each_with_index.drop(drop).to_enum { enumerable.size - drop })
     end
 
     # Builds Enumerator from Active Record Relation. Each Enumerator tick moves the cursor one row forward.


### PR DESCRIPTION
When building an `Array` `Enumerator`, we attach the size. Presumably, this size should reflect if we've dropped any elements, which it currently doesn't.

This updates the size calculation to subtract any dropped elements.

I wanted to add an accompanying test (or consult existing tests to see if this is expected behaviour), but I was unable to find anywhere we test `Array` `Enumerator`s, other than incidentally in some of the `ThrottleEnumerator` tests. 🤔 