### PR TITLE
Handle rails/rails branch change from `master` to `main`

### DIFF
--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -2,5 +2,5 @@
 
 eval_gemfile '../Gemfile'
 
-gem 'activejob', github: 'rails/rails'
-gem 'activerecord', github: 'rails/rails'
+gem 'activejob', github: 'rails/rails', branch: 'main'
+gem 'activerecord', github: 'rails/rails', branch: 'main'


### PR DESCRIPTION
I noticed that [CI is broken when testing against "edge" rails](https://travis-ci.com/github/Shopify/job-iteration/jobs/473575020) because Bundler assumes we want the `master` branch of `rails/rails`, which has recently changed its `HEAD` branch to `main`.

Ideally, this would be handled in Bundler itself (could it look at whatever `origin/HEAD` is?), or with GitHub providing a branch alias or something, but in the meantime we can explicitly provide the branch name.