### PR TITLE
Don't use MySQL password with Railgun

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -12,8 +12,8 @@ up:
   - bundler
   - custom:
       name: Create Job Iteration database
-      meet: mysql -uroot -h job-iteration.railgun -proot -e "CREATE DATABASE job_iteration_test"
-      met?: mysql -uroot -h job-iteration.railgun -proot job_iteration_test -e "SELECT 1"
+      meet: mysql -uroot -h job-iteration.railgun -e "CREATE DATABASE job_iteration_test"
+      met?: mysql -uroot -h job-iteration.railgun job_iteration_test -e "SELECT 1"
 
 commands:
   test: bundle exec rake

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,9 +51,9 @@ connection_config = {
   adapter: "mysql2",
   database: "job_iteration_test",
   username: 'root',
-  password: 'root',
   host: host,
 }
+connection_config[:password] = 'root' if ENV['CI']
 
 ActiveRecord::Base.establish_connection(connection_config)
 


### PR DESCRIPTION
I shipped https://github.com/Shopify/job-iteration/pull/67 to switch travis over to GH actions, and in the process updated the MySQL [connection config ](https://github.com/Shopify/job-iteration/pull/67/files#diff-ba37813ca277c227a74a372479b7b05b7f3ff085d890ab708f80d62573efdb7aR54)to take `password=root`, since that it what the Ubuntu VM requires for MySQL.

I also updated the [dev.yml](https://github.com/Shopify/job-iteration/pull/67/files#diff-26fac0c0264ace68fab9c60b467544b6c45f3f46d82c270a73bc28681fd45096R15-R16) to use this new password. However, what I failed to realize is that the Railgun VM does not want a password (presumably bc it's a Linux VM), so `dev up` currently breaks 😬 

What we need to do instead is _only_ use a password if we're using `localhost` as the host for our DB connection, and _not_ require a password for Railgun.

Consequently, I've made the following changes:
- Specify the password as `root` in the db connection only if we're not using dev
- Don't use password option in dev.yml anymore
- Update `bin/setup` to specify password option of `root`