### PR TITLE
Fix memory leak in active record cursor

### DIFF
--- a/lib/job-iteration/active_record_cursor.rb
+++ b/lib/job-iteration/active_record_cursor.rb
@@ -64,7 +64,9 @@ module JobIteration
         relation = relation.where(*conditions)
       end
 
-      records = relation.to_a
+      records = relation.uncached do
+        relation.to_a
+      end
 
       update_from_record(records.last) unless records.empty?
       @reached_end = records.size < batch_size


### PR DESCRIPTION
This commit patches the active record cursor implementation so that the
queries emitted by `relation.to_a` in `next_batch` are never cached.
This makes sense because it is a waste to cache results of queries like
`SELECT ... WHERE id > ... LIMIT ...` in an enumerator that is only
moving forward.

The `uncached` interface I make use of in this commit was introduced by
rails/rails#28867 under a similar context.