### PR TITLE
Enforce cursor be serializable

### DIFF
--- a/test/integration/sidekiq_test.rb
+++ b/test/integration/sidekiq_test.rb
@@ -39,6 +39,22 @@ class SidekiqIntegrationTest < ActiveSupport::TestCase
     assert_equal 0, queue_size
   end
 
+  test "unserializable cursor corruption is prevented" do
+    # Sidekiq serializes cursors as JSON, but not all objects are serializable.
+    #     time   = Time.at(0).utc   # => 1970-01-01 00:00:00 UTC
+    #     json   = JSON.dump(time)  # => "\"1970-01-01 00:00:00 UTC\""
+    #     string = JSON.parse(json) # => "1970-01-01 00:00:00 UTC"
+    # We serialized a Time, but it was deserialized as a String.
+    TimeCursorJob.perform_later
+    TerminateJob.perform_later
+    start_sidekiq_and_wait
+
+    assert_equal(
+      JobIteration::Iteration::CursorError.name,
+      failed_job_error_class_name,
+    )
+  end
+
   private
 
   def start_sidekiq_and_wait
@@ -49,5 +65,9 @@ class SidekiqIntegrationTest < ActiveSupport::TestCase
 
   def queue_size
     Sidekiq::Queue.new.size
+  end
+
+  def failed_job_error_class_name
+    Sidekiq::RetrySet.new.first&.item&.fetch("error_class")
   end
 end

--- a/test/support/jobs.rb
+++ b/test/support/jobs.rb
@@ -15,6 +15,19 @@ class IterationJob < ActiveJob::Base
   end
 end
 
+class TimeCursorJob < ActiveJob::Base
+  include JobIteration::Iteration
+
+  def build_enumerator(cursor:)
+    return [["item", Time.now]].to_enum if cursor.nil?
+
+    raise "This should never run; cursor is unserializable!"
+  end
+
+  def each_iteration(*)
+  end
+end
+
 class TerminateJob < ActiveJob::Base
   def perform
     Process.kill("TERM", Process.pid)

--- a/test/unit/iteration_test.rb
+++ b/test/unit/iteration_test.rb
@@ -63,6 +63,64 @@ class JobIterationTest < IterationUnitTest
     end
   end
 
+  class InvalidCursorJob < ActiveJob::Base
+    include JobIteration::Iteration
+    def each_iteration(*)
+      raise "Cursor invalid. This should never run!"
+    end
+  end
+
+  class JobWithTimeCursor < InvalidCursorJob
+    def build_enumerator(cursor:)
+      [["item", cursor || Time.now]].to_enum
+    end
+  end
+
+  class JobWithSymbolCursor < InvalidCursorJob
+    def build_enumerator(cursor:)
+      [["item", cursor || :symbol]].to_enum
+    end
+  end
+
+  class JobWithActiveRecordCursor < InvalidCursorJob
+    def build_enumerator(cursor:)
+      [["item", cursor || Product.first]].to_enum
+    end
+  end
+
+  class JobWithStringSubclassCursor < InvalidCursorJob
+    StringSubClass = Class.new(String)
+
+    def build_enumerator(cursor:)
+      [["item", cursor || StringSubClass.new]].to_enum
+    end
+  end
+
+  class JobWithBasicObjectCursor < InvalidCursorJob
+    def build_enumerator(cursor:)
+      [["item", cursor || BasicObject.new]].to_enum
+    end
+  end
+
+  class JobWithComplexCursor < ActiveJob::Base
+    include JobIteration::Iteration
+    def build_enumerator(cursor:)
+      [[
+        "item",
+        cursor || [{
+          "string" => "abc",
+          "integer" => 123,
+          "float" => 4.56,
+          "booleans" => [true, false],
+          "null" => nil,
+        }],
+      ]].to_enum
+    end
+
+    def each_iteration(*)
+    end
+  end
+
   def test_jobs_that_define_build_enumerator_and_each_iteration_will_not_raise
     push(JobWithRightMethods, "walrus" => "best")
     work_one_job
@@ -124,7 +182,53 @@ class JobIterationTest < IterationUnitTest
     assert_includes(methods_added, :foo)
   end
 
+  def test_jobs_using_time_cursor_will_raise
+    push(JobWithTimeCursor)
+    assert_raises_cursor_error { work_one_job }
+  end
+
+  def test_jobs_using_active_record_cursor_will_raise
+    refute_nil(Product.first)
+    push(JobWithActiveRecordCursor)
+    assert_raises_cursor_error { work_one_job }
+  end
+
+  def test_jobs_using_symbol_cursor_will_raise
+    push(JobWithSymbolCursor)
+    assert_raises_cursor_error { work_one_job }
+  end
+
+  def test_jobs_using_string_subclass_cursor_will_raise
+    push(JobWithStringSubclassCursor)
+    assert_raises_cursor_error { work_one_job }
+  end
+
+  def test_jobs_using_basic_object_cursor_will_raise
+    push(JobWithBasicObjectCursor)
+    assert_raises_cursor_error { work_one_job }
+  end
+
+  def test_jobs_using_complex_but_serializable_cursor_will_not_raise
+    push(JobWithComplexCursor)
+    work_one_job
+  end
+
   private
+
+  def assert_raises_cursor_error(&block)
+    error = assert_raises(JobIteration::Iteration::CursorError, &block)
+    inspected_cursor = begin
+                         error.cursor.inspect
+                       rescue NoMethodError
+                         Object.instance_method(:inspect).bind(error.cursor).call
+                       end
+    assert_equal(
+      "Cursor must be composed of objects capable of built-in (de)serialization: " \
+      "Strings, Integers, Floats, Arrays, Hashes, true, false, or nil. " \
+      "(#{inspected_cursor})",
+      error.message,
+    )
+  end
 
   def push(job, *args)
     job.perform_later(*args)


### PR DESCRIPTION
## Context & Problem

The `cursor_position` is serialized by the job adapter (Resque/Sidekiq) and bypasses Active Job's fancy serialization. Both Resque and Sidekiq effectively use `JSON.dump` to serialize it and `JSON.parse` to deserialize it.

In cases where a non-JSON-compatible cursor is used, it is silently turned into a `String` via `to_s`, which can lead to weird errors when the job resumes after interruption. These are not always straightforward to debug, and don't reliably show up in tests, as Active Support adds implicit coercions to some object's `==` method.

```ruby
time = Time.at(0).utc               # =>  1970-01-01 00:00:00 UTC  (Time)
time.to_s                           # => "1970-01-01 00:00:00 UTC" (String)
require 'json'
JSON.parse(JSON.dump(time))         # => "1970-01-01 00:00:00 UTC" (String)
time == JSON.parse(JSON.dump(time)) # => false                     (no coercion)
require 'active_support/all'
JSON.parse(JSON.dump(time))         # => "1970-01-01 00:00:00 UTC" (String)
time == JSON.parse(JSON.dump(time)) # => true                      (implicitly coerced)
```

<details><summary>Real world example</summary>
In one of our repos, we use a custom enumerator around a collection of events fetched from an API and ordered by time. We used the time the event occurred at as a cursor, which was "corrupted" by being serialized into a String. The API expected an ISO8601 timestamp (its wrapper gem converts `Time` objects automatically), but our improperly deserialized time strings were in the wrong format, so it blew up.

This went unnoticed for some time, due to the job not being interrupted, and was tricky to debug due to the reasons outlined above.
</details>

## What this PR does about it

**This prevents these errors by enforcing that the cursors be composed of basic Ruby objects.**

This is enforced by (recursively) analyzing the each cursor yielded by the enumerator **before `each_iteration`**. If it is composed of anything other than the following classes, a descriptive `CursorError` is raised:
- `Array`
- `Hash`
- `String`
- `Integer`
- `Float`
- `NilClass` (`nil`)
- `TrueClass` (`true`)
- `FalseClass` (`false`)

### Rationale

- It is better to verify each cursor and ensure we'd be able to interrupt before having started any work, than to finding out the cursor is unsafe after interruption.
- It is fastest and most reliable to simply analyze the component classes of the cursor (rather than check if serializing and deserializing yields the same object, due to implicit conversions).
- Since most cursors are simple Strings, Integers, or `nil`, the performance penalty of checking each cursor is negligible.

----
<details><summary>Original Description</summary>
The cursor ends up being serialized as a `String`, regardless of if it is a `String` or not (by calling `to_s`).

This can lead to subtle bugs often not found during testing.

For instance, if a `Time` is used as a cursor and the job is requeued, it instead receives the `Time#to_s` representation as its new input cursor.

Let's be explicit and save developers the headache of debugging that: **let's enforce that the cursor be an instance of `String` or `NilClass`.**
</details>