### PR TITLE
Add Gemfile to GitHub Action Workflow label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: CI
 
 on: [push]
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: Ruby ${{ matrix.ruby }}
+    name: Ruby ${{ matrix.ruby }} | Gemfile ${{ matrix.gemfile }}
     services:
       redis:
         image: redis


### PR DESCRIPTION
Currently there appear to be duplicate workflows running. This is because the workflow only lists the Ruby version in its name.

However, the matrix also uses different `Gemfile`s. By adding those to the name, it becomes evident there are is no duplication.

This also renames the workflow from `Ruby` to `CI` to clean up the label.

Before|After Gemfile Label Addition|After Workflow Rename
-|-|-
![image](https://user-images.githubusercontent.com/8219340/115121795-9936c380-9f82-11eb-9b64-06d5e4c5f07d.png)|![image](https://user-images.githubusercontent.com/8219340/115121779-815f3f80-9f82-11eb-9e22-eb3006e05caa.png)|![image](https://user-images.githubusercontent.com/8219340/115283629-a0dca080-a119-11eb-93f6-f17b1275a513.png)
