### PR TITLE
Bump version to 1.1.11 & update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,20 @@
 
 #### Bug fix
 
+
+## v1.1.11 (April 19, 2021)
+
+#### Bug fix
+
+- [73](https://github.com/Shopify/job-iteration/pull/73) - Enforce cursor be serializable
+
 ## v1.1.10 (March 30, 2021)
 
-- [69](https://github.com/Shopify/job-iteration/pull/69) Fix memory leak in ActiveRecordCursor
+- [69](https://github.com/Shopify/job-iteration/pull/69) - Fix memory leak in ActiveRecordCursor
 
 ## v1.1.9 (January 6, 2021)
 
-- [61](https://github.com/Shopify/job-iteration/pull/61) Call `super` in `method_added`
+- [61](https://github.com/Shopify/job-iteration/pull/61) - Call `super` in `method_added`
 
 ## v1.1.8 (June 8, 2020)
 

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.1.10"
+  VERSION = "1.1.11"
 end


### PR DESCRIPTION
**This increments the patch version and updates the changelog, prior to cutting a new release.**

Only relevant change is enforcing serializable cursor (#73). Non-serializable cursors were always an "error", and their behaviour in the host job was "undefined", depending on the object and how the host job handled it. This change just makes the error loud and immediate, instead of silent and delayed until resumption following interruption; hence the patch version increment.