### PR TITLE
Defer enforcing cursor serializability until 2.0.0 (and publish 1.1.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@
 
 #### Bug fix
 
+## v1.1.12 (April 19, 2021)
+
+#### Bug fix
+
+- [77](https://github.com/Shopify/job-iteration/pull/77) - Defer enforce cursor be serializable until 2.0.0
 
 ## v1.1.11 (April 19, 2021)
 
 #### Bug fix
 
 - [73](https://github.com/Shopify/job-iteration/pull/73) - Enforce cursor be serializable
+  _This is reverted in 1.1.12 as it breaks behaviour in some apps._
 
 ## v1.1.10 (March 30, 2021)
 

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -142,7 +142,8 @@ module JobIteration
       arguments = arguments.dup.freeze
       found_record = false
       enumerator.each do |object_from_enumerator, index|
-        assert_valid_cursor!(index)
+        # Deferred until 2.0.0
+        # assert_valid_cursor!(index)
 
         record_unit_of_work do
           found_record = true

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.1.11"
+  VERSION = "1.1.12"
 end

--- a/test/integration/integration_behaviour.rb
+++ b/test/integration/integration_behaviour.rb
@@ -35,6 +35,7 @@ module IntegrationBehaviour
     end
 
     test "unserializable corruption is prevented" do
+      skip "Deferred until 2.0.0"
       # Cursors are serialized as JSON, but not all objects are serializable.
       #     time   = Time.at(0).utc   # => 1970-01-01 00:00:00 UTC
       #     json   = JSON.dump(time)  # => "\"1970-01-01 00:00:00 UTC\""

--- a/test/unit/iteration_test.rb
+++ b/test/unit/iteration_test.rb
@@ -183,32 +183,38 @@ class JobIterationTest < IterationUnitTest
   end
 
   def test_jobs_using_time_cursor_will_raise
+    skip("Deferred until 2.0.0")
     push(JobWithTimeCursor)
     assert_raises_cursor_error { work_one_job }
   end
 
   def test_jobs_using_active_record_cursor_will_raise
+    skip("Deferred until 2.0.0")
     refute_nil(Product.first)
     push(JobWithActiveRecordCursor)
     assert_raises_cursor_error { work_one_job }
   end
 
   def test_jobs_using_symbol_cursor_will_raise
+    skip("Deferred until 2.0.0")
     push(JobWithSymbolCursor)
     assert_raises_cursor_error { work_one_job }
   end
 
   def test_jobs_using_string_subclass_cursor_will_raise
+    skip("Deferred until 2.0.0")
     push(JobWithStringSubclassCursor)
     assert_raises_cursor_error { work_one_job }
   end
 
   def test_jobs_using_basic_object_cursor_will_raise
+    skip("Deferred until 2.0.0")
     push(JobWithBasicObjectCursor)
     assert_raises_cursor_error { work_one_job }
   end
 
   def test_jobs_using_complex_but_serializable_cursor_will_not_raise
+    skip("Deferred until 2.0.0")
     push(JobWithComplexCursor)
     work_one_job
   end


### PR DESCRIPTION
This has been identified as a breaking change that should not be in a patch version; we will release a major version instead.

This skips the enforcement code paths, skips the tests, and upgrades the patch version to `1.1.12`. A follow up PR can put them all back and release `2.0.0`.