### PR TITLE
Deprecate usage of cursors not safe to serialize

### DIFF
--- a/lib/job-iteration.rb
+++ b/lib/job-iteration.rb
@@ -9,6 +9,8 @@ module JobIteration
 
   INTEGRATIONS = [:resque, :sidekiq]
 
+  Deprecation = ActiveSupport::Deprecation.new("2.0", "JobIteration")
+
   extend self
 
   # Use this to _always_ interrupt the job after it's been running for more than N seconds.

--- a/test/integration/integration_behaviour.rb
+++ b/test/integration/integration_behaviour.rb
@@ -35,7 +35,7 @@ module IntegrationBehaviour
     end
 
     test "unserializable corruption is prevented" do
-      skip "Deferred until 2.0.0"
+      skip "Breaking change deferred until 2.0" if Gem::Version.new(JobIteration::VERSION) < Gem::Version.new("2.0")
       # Cursors are serialized as JSON, but not all objects are serializable.
       #     time   = Time.at(0).utc   # => 1970-01-01 00:00:00 UTC
       #     json   = JSON.dump(time)  # => "\"1970-01-01 00:00:00 UTC\""


### PR DESCRIPTION
## TL;DR

This is a redo of #73, but using a deprecation warning instead of raising an error. The error is deferred until `2.0`.

## Details

It is unsafe to use cursors which cannot be serialized using JSON.dump and deserialized again using JSON.parse. Such cursors may result in a different cursor being deserialized, or in serialization failing entirely, which may result in incorrect behaviour in iterative jobs.

Starting in 2.0, usage of such cursors will raise an ArgumentError. Until then, a deprecation warning will be logged.

#73 contains more context on the change, and #80 contains information as to the motivation for this alternative approach.

----

Closes #80