### PR TITLE
adjust_total_time before running on_complete callbacks

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -162,6 +162,8 @@ module JobIteration
         "times_interrupted=#{times_interrupted} cursor_position=#{cursor_position}"
       ) unless found_record
 
+      adjust_total_time
+
       true
     end
 
@@ -249,8 +251,6 @@ module JobIteration
     end
 
     def output_interrupt_summary
-      adjust_total_time
-
       message = "[JobIteration::Iteration] Completed iterating. times_interrupted=%d total_time=%.3f"
       logger.info(Kernel.format(message, times_interrupted, total_time))
     end


### PR DESCRIPTION
Closes #83

### What are you trying to accomplish?

We were using the `on_complete` callback to report the job total run time but we noticed that `total_time` only gets updated after the callbacks are called.

### What approach did you choose and why?

There were 3 options:
1. Move `adjust_total_time` so that it's called before the callbacks.
2. Copy `adjust_total_time` so that it's called before the callbacks and also right before logging the output summary. This could be useful in case the "total_time after callbacks" is valuable.
3. Publish a new event via `ActiveSupport::Notifications.instrument` instead. This would overlap with the callback functionality.

I decided for 1 because I think it's the one that makes the most sense.

### What reviewers should focus on?

- I'm not familiar with writing RubyGems so I added Timecop as a dependency without a group. If that's problematic I can try to come up with another solution to stub the passage of time.
- I would consider this a bugfix but if users are relying on the inaccurate `total_time` inside `on_complete` callbacks, this patch would be a breaking change.
