### PR TITLE
Add a section about risks of using columns argument

### DIFF
--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -86,6 +86,11 @@ module JobIteration
     #        WHERE (created_at > '$LAST_CREATED_AT_CURSOR'
     #          OR (created_at = '$LAST_CREATED_AT_CURSOR' AND (id > '$LAST_ID_CURSOR')))
     #        ORDER BY created_at, id LIMIT 100
+    #
+    # As a result of this query pattern, if the values in these columns change for the records in scope during
+    # iteration, they may be skipped or yielded multiple times depending on the nature of the update and the
+    # cursor's value. If the value gets updated to a greater value than the cursor's value, it will get yielded
+    # again. Similarly, if the value gets updated to a lesser value than the curor's value, it will get skipped.
     def build_active_record_enumerator_on_records(scope, cursor:, **args)
       enum = build_active_record_enumerator(
         scope,


### PR DESCRIPTION
When the columns argument is used with the
`build_active_record_enumerator`, the enumerator may
skip or yield records multiple times.

I've highlighted how these can happen in this PR: https://github.com/Shopify/job-iteration/pull/82

@grcooper @Mangara I decided to add this comment to the only place where it talks about the `columns` option, instead of here: https://github.com/Shopify/job-iteration/blob/master/guides/iteration-how-it-works.md 

Also, it's a bit challenging to explain this edge case in a few sentences, so please help me clarify it better if it looks unclear.

Let me know what you think about it.