### PR TITLE
Adds `as_relation` flag to `EnumeratorBuilder#active_record_on_batches`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,28 @@ class BatchesJob < ApplicationJob
 
   def each_iteration(batch_of_comments, product_id)
     # batch_of_comments will contain batches of 100 records
-    Comment.where(id: batch_of_comments.map(&:id)).update_all(deleted: true)
+    batch_of_comments.each do |comment|
+      DeleteCommentJob.perform_later(comment)
+    end
+  end
+end
+```
+
+```ruby
+class BatchesAsRelationJob < ApplicationJob
+  include JobIteration::Iteration
+
+  def build_enumerator(product_id, cursor:)
+    enumerator_builder.active_record_on_batches_as_relation(
+      Product.find(product_id).comments,
+      cursor: cursor,
+      batch_size: 100,
+    )
+  end
+
+  def each_iteration(batch_of_comments, product_id)
+    # batch_of_comments will be a Comment::ActiveRecord_Relation
+    batch_of_comments.update_all(deleted: true)
   end
 end
 ```

--- a/lib/job-iteration/active_record_enumerator.rb
+++ b/lib/job-iteration/active_record_enumerator.rb
@@ -6,9 +6,10 @@ module JobIteration
   class ActiveRecordEnumerator
     SQL_DATETIME_WITH_NSEC = "%Y-%m-%d %H:%M:%S.%N"
 
-    def initialize(relation, columns: nil, batch_size: 100, cursor: nil)
+    def initialize(relation, columns: nil, batch_size: 100, as_relation: false, cursor: nil)
       @relation = relation
       @batch_size = batch_size
+      @as_relation = as_relation
       @columns = Array(columns || "#{relation.table_name}.#{relation.primary_key}")
       @cursor = cursor
     end
@@ -26,7 +27,7 @@ module JobIteration
     def batches
       cursor = finder_cursor
       Enumerator.new(method(:size)) do |yielder|
-        while (records = cursor.next_batch(@batch_size))
+        while (records = cursor.next_batch(@batch_size, @as_relation))
           yielder.yield(records, cursor_value(records.last)) if records.any?
         end
       end

--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -110,6 +110,18 @@ module JobIteration
       wrap(self, enum)
     end
 
+    # Builds Enumerator from Active Record Relation and enumerates on batches, yielding Active Record Relations.
+    # See documentation for #build_active_record_enumerator_on_batches.
+    def build_active_record_enumerator_on_batches_as_relation(scope, cursor:, **args)
+      enum = build_active_record_enumerator(
+        scope,
+        cursor: cursor,
+        as_relation: true,
+        **args
+      ).batches
+      wrap(self, enum)
+    end
+
     def build_throttle_enumerator(enum, throttle_on:, backoff:)
       JobIteration::ThrottleEnumerator.new(
         enum,
@@ -124,6 +136,7 @@ module JobIteration
     alias_method :array, :build_array_enumerator
     alias_method :active_record_on_records, :build_active_record_enumerator_on_records
     alias_method :active_record_on_batches, :build_active_record_enumerator_on_batches
+    alias_method :active_record_on_batches_as_relation, :build_active_record_enumerator_on_batches_as_relation
     alias_method :throttle, :build_throttle_enumerator
 
     private


### PR DESCRIPTION
Currently, the resulting batch from `#active_record_on_batches` is an Array of records. Many job authors end up converting this into a relation to perform batch operations such as `#update_all` (even the existing `BatchesJob` example in the README does this!). By expanding the API of `#active_record_on_batches` to return a relation if a flag is set, users who require their batch as an `ActiveRecord::Relation` will no longer need to perform an additional query to turn records back into a relation.

This has no effect on existing jobs, since by default `as_relation` will be set to false and batches will continue to be converted to Arrays.

Not sure whether it's worth documenting an example of this in the README, or whether the API documentation is sufficient.