### PR TITLE
Optimize edge case in throttle enumerator

### DIFF
--- a/lib/job-iteration/throttle_enumerator.rb
+++ b/lib/job-iteration/throttle_enumerator.rb
@@ -34,7 +34,7 @@ module JobIteration
             throw(:abort, :skip_complete_callbacks)
           end
 
-          yielder.yield(*@enum.next)
+          yielder.yield(*@enum.next_values)
         end
       end
     end

--- a/lib/job-iteration/throttle_enumerator.rb
+++ b/lib/job-iteration/throttle_enumerator.rb
@@ -27,14 +27,14 @@ module JobIteration
 
     def to_enum
       Enumerator.new(-> { @enum.size }) do |yielder|
-        @enum.each do |*val|
+        loop do
           if should_throttle?
             ActiveSupport::Notifications.instrument("throttled.iteration", job_class: @job.class.name)
             @job.retry_job(wait: @backoff)
             throw(:abort, :skip_complete_callbacks)
           end
 
-          yielder.yield(*val)
+          yielder.yield(*@enum.next)
         end
       end
     end


### PR DESCRIPTION
Currently when using the throttle enumerator, even when throttled, the first value of the passed enumerator is evaluated.
This may be problematic in cases when we're throttling based on database health, as we will still perform an ActiveRecord query when throttled.

This PR updates the throttle enumerator to check the throttler before evaluating the next value.

