### PR TITLE
Batch Enumerator Yielding Relations

### DIFF
--- a/lib/job-iteration/active_record_batch_enumerator.rb
+++ b/lib/job-iteration/active_record_batch_enumerator.rb
@@ -60,8 +60,7 @@ module JobIteration
       @cursor = Array.wrap(cursor)
 
       # Yields relations by selecting the primary keys of records in the batch.
-      # Post.where(published: nil)
-      # results in an enumerator of relations like Post.where(ids: batch_of_ids)
+      # Post.where(published: nil) results in an enumerator of relations like: Post.where(ids: batch_of_ids)
       @base_relation.where(@primary_key => ids)
     end
 
@@ -72,9 +71,10 @@ module JobIteration
       end
 
       column_values = relation.pluck(*@pluck_columns)
-      primary_key_values = column_values.map { |values| values[@primary_key_index || -1] }
+      primary_key_index = @primary_key_index || -1
+      primary_key_values = column_values.map { |values| values[primary_key_index] }
 
-      column_values.map! { |values| values.map! { |value| column_value(value) } }
+      serialize_column_values!(column_values)
       [column_values, primary_key_values]
     end
 
@@ -99,6 +99,10 @@ module JobIteration
       ret = @cursor.reduce([where_clause]) { |params, value| params << value << value }
       ret.pop
       ret
+    end
+
+    def serialize_column_values!(column_values)
+      column_values.map! { |values| values.map! { |value| column_value(value) } }
     end
 
     def column_value(value)

--- a/lib/job-iteration/active_record_batch_enumerator.rb
+++ b/lib/job-iteration/active_record_batch_enumerator.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module JobIteration
+  # Builds Batch Enumerator based on ActiveRecord Relation.
+  # @see EnumeratorBuilder
+  class ActiveRecordBatchEnumerator
+    include Enumerable
+
+    SQL_DATETIME_WITH_NSEC = "%Y-%m-%d %H:%M:%S.%N"
+
+    def initialize(relation, columns: nil, batch_size: 100, cursor: nil)
+      @batch_size = batch_size
+      @primary_key = "#{relation.table_name}.#{relation.primary_key}"
+      @columns = Array(columns&.map(&:to_s) || @primary_key)
+      @primary_key_index = @columns.index(@primary_key) || @columns.index(relation.primary_key)
+      @pluck_columns = if @primary_key_index
+        @columns
+      else
+        @columns.dup << @primary_key
+      end
+      @cursor = Array.wrap(cursor)
+      raise ArgumentError, "Must specify at least one column" if @columns.empty?
+      if relation.joins_values.present? && !@columns.all? { |column| column.to_s.include?(".") }
+        raise ArgumentError, "You need to specify fully-qualified columns if you join a table"
+      end
+
+      if relation.arel.orders.present? || relation.arel.taken.present?
+        raise ConditionNotSupportedError
+      end
+
+      @base_relation = relation.reorder(@columns.join(","))
+    end
+
+    def each
+      while (relation = next_batch)
+        break if @cursor.empty?
+        yield relation, cursor_value
+      end
+    end
+
+    def size
+      @base_relation.count
+    end
+
+    private
+
+    def next_batch
+      relation = @base_relation.limit(@batch_size)
+      if conditions.any?
+        relation = relation.where(*conditions)
+      end
+
+      cursor_values, ids = relation.uncached do
+        pluck_columns(relation)
+      end
+
+      cursor = cursor_values.last
+      # The primary key was plucked, but original cursor did not include it
+      cursor.pop unless @primary_key_index || cursor.nil?
+      @cursor = Array.wrap(cursor)
+
+      # Yields relations by selecting the primary keys of records in the batch.
+      # Post.where(published: nil)
+      # results in an enumerator of relations like Post.where(ids: batch_of_ids)
+      @base_relation.where(@primary_key => ids)
+    end
+
+    def pluck_columns(relation)
+      if @pluck_columns.size == 1 # only the primary key
+        column_values = relation.pluck(*@pluck_columns)
+        return [column_values, column_values]
+      end
+
+      column_values = relation.pluck(*@pluck_columns)
+      primary_key_values = column_values.map { |values| values[@primary_key_index || -1] }
+
+      column_values.map! { |values| values.map! { |value| column_value(value) } }
+      [column_values, primary_key_values]
+    end
+
+    def cursor_value
+      return @cursor.first if @cursor.size == 1
+      @cursor
+    end
+
+    def conditions
+      column_index = @cursor.size - 1
+      column = @columns[column_index]
+      where_clause = if @columns.size == @cursor.size
+        "#{column} > ?"
+      else
+        "#{column} >= ?"
+      end
+      while column_index > 0
+        column_index -= 1
+        column = @columns[column_index]
+        where_clause = "#{column} > ? OR (#{column} = ? AND (#{where_clause}))"
+      end
+      ret = @cursor.reduce([where_clause]) { |params, value| params << value << value }
+      ret.pop
+      ret
+    end
+
+    def column_value(value)
+      value.is_a?(Time) ? value.strftime(SQL_DATETIME_WITH_NSEC) : value
+    end
+  end
+end

--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require_relative "./active_record_batch_enumerator"
 require_relative "./active_record_enumerator"
 require_relative "./csv_enumerator"
 require_relative "./throttle_enumerator"
@@ -100,7 +101,7 @@ module JobIteration
       wrap(self, enum)
     end
 
-    # Builds Enumerator from Active Record Relation and enumerates on batches.
+    # Builds Enumerator from Active Record Relation and enumerates on batches of records.
     # Each Enumerator tick moves the cursor +batch_size+ rows forward.
     #
     # +batch_size:+ sets how many records will be fetched in one batch. Defaults to 100.
@@ -112,6 +113,17 @@ module JobIteration
         cursor: cursor,
         **args
       ).batches
+      wrap(self, enum)
+    end
+
+    # Builds Enumerator from Active Record Relation and enumerates on batches, yielding Active Record Relations.
+    # See documentation for #build_active_record_enumerator_on_batches.
+    def build_active_record_enumerator_on_batch_relations(scope, cursor:, **args)
+      enum = JobIteration::ActiveRecordBatchEnumerator.new(
+        scope,
+        cursor: cursor,
+        **args
+      )
       wrap(self, enum)
     end
 
@@ -129,6 +141,7 @@ module JobIteration
     alias_method :array, :build_array_enumerator
     alias_method :active_record_on_records, :build_active_record_enumerator_on_records
     alias_method :active_record_on_batches, :build_active_record_enumerator_on_batches
+    alias_method :active_record_on_batch_relations, :build_active_record_enumerator_on_batch_relations
     alias_method :throttle, :build_throttle_enumerator
 
     private

--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -75,6 +75,20 @@ module JobIteration
       end
     end
 
+    class BatchActiveRecordRelationIterationJob < SimpleIterationJob
+      def build_enumerator(cursor:)
+        enumerator_builder.active_record_on_batch_relations(
+          Product.all,
+          cursor: cursor,
+          batch_size: 3,
+        )
+      end
+
+      def each_iteration(relation)
+        self.class.records_performed << relation
+      end
+    end
+
     class AbortingActiveRecordIterationJob < ActiveRecordIterationJob
       def each_iteration(*)
         abort_strategy if self.class.records_performed.size == 2
@@ -446,6 +460,18 @@ module JobIteration
 
       assert_equal(1, BatchActiveRecordIterationJob.on_start_called)
       assert_equal(1, BatchActiveRecordIterationJob.on_complete_called)
+    end
+
+    def test_activerecord_batch_relations
+      push(BatchActiveRecordRelationIterationJob)
+
+      work_one_job
+      assert_jobs_in_queue(0)
+
+      records_performed = BatchActiveRecordIterationJob.records_performed
+      assert_equal([3, 3, 3, 1], records_performed.map(&:size))
+      assert(records_performed.all? { |relation| relation.is_a?(ActiveRecord::Relation) })
+      assert(records_performed.none?(&:loaded?))
     end
 
     def test_multiple_columns

--- a/test/unit/active_record_batch_enumerator_test.rb
+++ b/test/unit/active_record_batch_enumerator_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module JobIteration
+  class ActiveRecordBatchEnumeratorTest < IterationUnitTest
+    SQL_TIME_FORMAT = "%Y-%m-%d %H:%M:%S.%N"
+    test "#each yields batches as relation with the last record's cursor position" do
+      enum = build_enumerator
+      product_batches = Product.order(:id).take(4).in_groups_of(2).map { |product| [product, product.last.id] }
+
+      enum.first(2).each_with_index do |(batch, cursor), index|
+        assert batch.is_a?(ActiveRecord::Relation)
+        assert_equal product_batches[index].first, batch
+        assert_equal product_batches[index].last, cursor
+      end
+    end
+
+    test "#each yields unloaded relations" do
+      enum = build_enumerator
+      relation, _ = enum.first
+
+      refute_predicate relation, :loaded?
+    end
+
+    test "#each doesn't yield anything if the relation is empty" do
+      enum = build_enumerator(relation: Product.none)
+
+      assert_equal([], enum.to_a)
+    end
+
+    test "batch size is configurable" do
+      enum = build_enumerator(batch_size: 4)
+      products = Product.order(:id).take(4)
+
+      assert_equal([products, products.last.id], enum.first)
+    end
+
+    test "columns are configurable" do
+      enum = build_enumerator(columns: [:updated_at])
+      products = Product.order(:updated_at).take(2)
+
+      expected_product_cursor = products.last.updated_at.strftime(SQL_TIME_FORMAT)
+      assert_equal([products, expected_product_cursor], enum.first)
+    end
+
+    test "columns can be an array" do
+      enum = build_enumerator(columns: [:updated_at, :id])
+      products = Product.order(:updated_at, :id).take(2)
+
+      expected_product_cursor = [products.last.updated_at.strftime(SQL_TIME_FORMAT), products.last.id]
+      assert_equal([products, expected_product_cursor], enum.first)
+    end
+
+    test "columns configured with primary key only queries primary key column once" do
+      queries = track_uncached_queries do
+        enum = build_enumerator(columns: [:updated_at, :id])
+        enum.first
+      end
+      assert_equal 1, queries.first.scan(/`products`.`id`/).count
+    end
+
+    test "cursor can be used to resume" do
+      products = Product.order(:id).take(3)
+
+      enum = build_enumerator(cursor: products.shift.id)
+
+      assert_equal([products, products.last.id], enum.first)
+    end
+
+    test "cursor can be used to resume on multiple columns" do
+      enum = build_enumerator(columns: [:created_at, :id])
+      products = Product.order(:created_at, :id).take(2)
+
+      cursor = [products.last.created_at.strftime(SQL_TIME_FORMAT), products.last.id]
+      assert_equal([products, cursor], enum.first)
+
+      enum = build_enumerator(columns: [:created_at, :id], cursor: cursor)
+      products = Product.order(:created_at, :id).offset(2).take(2)
+
+      cursor = [products.last.created_at.strftime(SQL_TIME_FORMAT), products.last.id]
+      assert_equal([products, cursor], enum.first)
+    end
+
+    private
+
+    def build_enumerator(relation: Product.all, batch_size: 2, columns: nil, cursor: nil)
+      JobIteration::ActiveRecordBatchEnumerator.new(
+        relation,
+        batch_size: batch_size,
+        columns: columns,
+        cursor: cursor,
+      )
+    end
+
+    def track_uncached_queries(&block)
+      queries = []
+      query_cb = ->(*, payload) { queries << payload[:sql] unless payload[:cached] }
+      ActiveSupport::Notifications.subscribed(query_cb, "sql.active_record", &block)
+      queries
+    end
+  end
+end


### PR DESCRIPTION
Take two of #86 

## Context
- Currently, the resulting batch from `#active_record_on_batches` is an array of records
- Many job authors ultimately want a relation (ie. to perform a batch operation such as `#update_all` or `#delete_all`) and convert this to a relation: `Model.where(id: records.map(&:id)).update_all`. This produces an extra query
- Not only do we perform this extra query, but we've already loaded the full records into memory, when instead we could optimize and only pluck the cursor-related columns to produce the cursor

## Proposed Solution
- New API for returning an enumerator yielding batch relations: `#active_record_on_batch_relations`, leaving existing batch enumerator API for records intact
- We're written this as a new enumerator class, `ActiveRecordBatchEnumerator`. The existing `ActiveRecordEnumerator` enumerator and `ActiveRecordCursor` classes have a lot of duplication and should probably be refactored. I intend to go back and abstract away cursor-related details from this new `ActiveRecordBatchEnumerator` class, while also fixing up the existing `ActiveRecordCursor`, in a separate PR.
- This new class is an actual `Enumerator` and defines `#each`
- This new batch enumerator has two key optimizations to note:
     - Instead of using `record = relation.last` and then querying the cursor columns on the `record` to construct the cursor, [we pluck _only_ the cursor columns](https://github.com/Shopify/job-iteration/compare/batch-enumerator?expand=1#diff-910f147f7f9b7040713e971f5b348b6085fc95f263730453546d7c4a6b4bf553R73). `relation.last` will load all of the records because we are using a `LIMIT`, as described [here](https://github.com/Shopify/job-iteration/pull/86#issuecomment-839894209). Consequently, we optimize by only plucking what we need.
     - We build the relation to yield using the [primary keys of the records in the original relation](https://github.com/Shopify/job-iteration/compare/batch-enumerator?expand=1#diff-910f147f7f9b7040713e971f5b348b6085fc95f263730453546d7c4a6b4bf553R64). Since we have these values anyways, building a relation based on the PKs ends up being much more efficient for the user when they load the relation inside `#each_iteration` than reusing the original relation (which may have had complex logic / joins / etc). This was actually inspired by how Rails does [`#in_batches`](https://github.com/rails/rails/blob/main/activerecord/lib/active_record/relation/batches.rb#L230-L238)
-  The rest of the logic is pretty similar to what's in `ActiveRecordEnumerator` and `ActiveRecordCursor`, with some simplifications, given that now everything is happening within a single object.

## End Result
- Users can enumerate on relations directly
- These relations are not loaded when they are yielded
- We perform a single query per batch, `SELECT <cursor_columns> FROM relation LIMIT <batch_size>`