### PR TITLE
Define size for ActiveRecordBatchEnumerator enumerator

### DIFF
--- a/lib/job-iteration/active_record_batch_enumerator.rb
+++ b/lib/job-iteration/active_record_batch_enumerator.rb
@@ -32,13 +32,10 @@ module JobIteration
     end
 
     def each
-      if block_given?
-        while (relation = next_batch)
-          break if @cursor.nil?
-          yield relation, cursor_value
-        end
-      else
-        to_enum(:each)
+      return to_enum { size } unless block_given?
+      while (relation = next_batch)
+        break if @cursor.nil?
+        yield relation, cursor_value
       end
     end
 

--- a/test/unit/active_record_batch_enumerator_test.rb
+++ b/test/unit/active_record_batch_enumerator_test.rb
@@ -24,8 +24,9 @@ module JobIteration
     end
 
     test "#each yields enumerator when called without a block" do
-      enum = build_enumerator
-      assert enum.each.is_a?(Enumerator)
+      enum = build_enumerator.each
+      assert enum.is_a?(Enumerator)
+      assert_not_nil enum.size
     end
 
     test "#each doesn't yield anything if the relation is empty" do


### PR DESCRIPTION
Follow-up to #91 
As mentioned in https://github.com/Shopify/job-iteration/pull/91#discussion_r636419553, the enumerator returned when `each` doesn't define a size. This adds it.