### PR TITLE
Remove unnecessary `break`

### DIFF
--- a/lib/job-iteration/active_record_batch_enumerator.rb
+++ b/lib/job-iteration/active_record_batch_enumerator.rb
@@ -34,7 +34,6 @@ module JobIteration
     def each
       return to_enum { size } unless block_given?
       while (relation = next_batch)
-        break if @cursor.nil?
         yield relation, cursor_value
       end
     end


### PR DESCRIPTION
As found in https://github.com/Shopify/job-iteration/pull/91/files#r640255068 we don't really need the break since `@cursor` can never be `nil`.