### PR TITLE
ActiveRecordBatchEnumerator#each should rewind at the end

### DIFF
--- a/lib/job-iteration/active_record_batch_enumerator.rb
+++ b/lib/job-iteration/active_record_batch_enumerator.rb
@@ -19,6 +19,7 @@ module JobIteration
         @columns.dup << @primary_key
       end
       @cursor = Array.wrap(cursor)
+      @initial_cursor = @cursor
       raise ArgumentError, "Must specify at least one column" if @columns.empty?
       if relation.joins_values.present? && !@columns.all? { |column| column.to_s.include?(".") }
         raise ArgumentError, "You need to specify fully-qualified columns if you join a table"
@@ -56,7 +57,10 @@ module JobIteration
       end
 
       cursor = cursor_values.last
-      return unless cursor.present?
+      unless cursor.present?
+        @cursor = @initial_cursor
+        return
+      end
       # The primary key was plucked, but original cursor did not include it, so we should remove it
       cursor.pop unless @primary_key_index
       @cursor = Array.wrap(cursor)

--- a/test/unit/active_record_batch_enumerator_test.rb
+++ b/test/unit/active_record_batch_enumerator_test.rb
@@ -16,6 +16,12 @@ module JobIteration
       end
     end
 
+    test "#each yields relations repeatedly" do
+      enum = build_enumerator(cursor: 2)
+      assert_equal 4, enum.to_a.size
+      assert_equal 4, enum.to_a.size
+    end
+
     test "#each yields unloaded relations" do
       enum = build_enumerator
       relation, _ = enum.first


### PR DESCRIPTION
While looking at the code for #94, I found out that our `each` is a bit surprising since it remembers its state (because it keeps the cursor). Calling `each` again on a enumerator doesn't iterate again, it doesn't yield.

Calling each twice in a row should yield all the batches again, like an Array or any Enumerator does:

```ruby
results = []
array = [1, 2]
array.each { |i| results << i }
array.each { |i| results << i }
results # => [1, 2, 1, 2]
```

I tested that by creating an enumerator with a cursor, and checking that we only get the remaining batches, twice. At first I reset the cursor entirely, but that would cause 4 batches first, then the full 5 batches on the second call to `each`, which was also an unexpected behavior. I don't really expect users to use this a lot but it's more correct at very little cost so worth it!