### PR TITLE
Batch enumerator size should return the number of batches, not records

### DIFF
--- a/lib/job-iteration/active_record_batch_enumerator.rb
+++ b/lib/job-iteration/active_record_batch_enumerator.rb
@@ -40,7 +40,7 @@ module JobIteration
     end
 
     def size
-      @base_relation.count
+      (@base_relation.count + @batch_size - 1) / @batch_size # ceiling division
     end
 
     private

--- a/test/unit/active_record_batch_enumerator_test.rb
+++ b/test/unit/active_record_batch_enumerator_test.rb
@@ -35,9 +35,11 @@ module JobIteration
       assert_equal([], enum.to_a)
     end
 
-    test "#size returns size of the base Active Record Relation" do
+    test "#size returns size of the Enumerator" do
       enum = build_enumerator
-      assert_equal Product.count, enum.size
+      assert_equal 5, enum.size # 5 batches of 2
+      enum = build_enumerator(batch_size: 3)
+      assert_equal 4, enum.size # 3 batches of 3, 1 batch of 1
     end
 
     test "batch size is configurable" do


### PR DESCRIPTION
Enumerator#size returns the number of yields, not the underlying number of elements, e.g.:

```ruby
[1,2,3].each_slice(2).size # => 2
```

Similarly BatchEnumerator#size should return the number of batches, not the number of records.
