### PR TITLE
Support nested iterations

### DIFF
--- a/lib/job-iteration/active_record_enumerator.rb
+++ b/lib/job-iteration/active_record_enumerator.rb
@@ -6,11 +6,12 @@ module JobIteration
   class ActiveRecordEnumerator
     SQL_DATETIME_WITH_NSEC = "%Y-%m-%d %H:%M:%S.%N"
 
-    def initialize(relation, columns: nil, batch_size: 100, cursor: nil)
+    def initialize(relation, columns: nil, batch_size: 100, cursor: nil, cursor_inclusive: false)
       @relation = relation
       @batch_size = batch_size
       @columns = Array(columns || "#{relation.table_name}.#{relation.primary_key}")
       @cursor = cursor
+      @cursor_inclusive = cursor_inclusive
     end
 
     def records
@@ -48,7 +49,7 @@ module JobIteration
     end
 
     def finder_cursor
-      JobIteration::ActiveRecordCursor.new(@relation, @columns, @cursor)
+      JobIteration::ActiveRecordCursor.new(@relation, @columns, @cursor, inclusive: @cursor_inclusive)
     end
 
     def column_value(record, attribute)

--- a/lib/job-iteration/active_record_nested_records_enumerator.rb
+++ b/lib/job-iteration/active_record_nested_records_enumerator.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+module JobIteration
+  class ActiveRecordNestedRecordsEnumerator
+    include Enumerable
+
+    def initialize(relations, columns: nil, batch_size: 100, cursor: nil)
+      assert_relations!(relations)
+
+      @relations = relations
+      @columns = columns
+      @batch_size = batch_size
+
+      @cursor = cursor || Array.new(relations.size)
+    end
+
+    def each
+      return to_enum unless block_given?
+
+      iterate_nested_records do |record, cursor_value|
+        yield record, cursor_value.dup
+      end
+    end
+
+    private
+
+    def assert_relations!(relations)
+      if !relations.is_a?(Array) || relations.empty?
+        raise ArgumentError, "relations must be a non-empty Array"
+      end
+
+      first_relation, *rest_relations = relations
+
+      unless first_relation.is_a?(ActiveRecord::Relation)
+        raise ArgumentError, "first relation must be an ActiveRecord::Relation"
+      end
+
+      unless rest_relations.all?(Proc)
+        raise ArgumentError, "all child relations must be Procs"
+      end
+    end
+
+    def iterate_nested_records(index = 0, records = [], cursor_values = [])
+      relation = @relations[index]
+      is_innermost = @relations.last == relation
+      relation = relation.call(*records) if relation.is_a?(Proc)
+      unless relation.is_a?(ActiveRecord::Relation)
+        raise ArgumentError, "all child relations must be ActiveRecord::Relations"
+      end
+
+      cursor = @cursor[index]
+
+      options = { batch_size: @batch_size }
+      if is_innermost
+        options[:columns] = @columns
+      else
+        # When running for the first time (no interruptions before), the cursor is nil.
+        # For subsequent runs we need to reiterate the same parent records.
+        options[:cursor_inclusive] = !cursor.nil?
+      end
+
+      ActiveRecordEnumerator.new(relation, cursor: cursor, **options).records.each do |record, cursor_value|
+        cursor_values.push(cursor_value)
+
+        if is_innermost
+          yield(record, cursor_values)
+        else
+          records.push(record)
+          iterate_nested_records(index + 1, records, cursor_values) do |*args|
+            yield(*args)
+          end
+          records.pop
+        end
+
+        cursor_values.pop
+      end
+    end
+  end
+end

--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require_relative "./active_record_batch_enumerator"
 require_relative "./active_record_enumerator"
+require_relative "./active_record_nested_records_enumerator"
 require_relative "./csv_enumerator"
 require_relative "./throttle_enumerator"
 require "forwardable"
@@ -135,6 +136,14 @@ module JobIteration
       ).to_enum
     end
 
+    def build_active_record_enumerator_on_nested_records(scopes, cursor:, **args)
+      JobIteration::ActiveRecordNestedRecordsEnumerator.new(
+        scopes,
+        cursor: cursor,
+        **args
+      ).each
+    end
+
     alias_method :once, :build_once_enumerator
     alias_method :times, :build_times_enumerator
     alias_method :array, :build_array_enumerator
@@ -142,6 +151,7 @@ module JobIteration
     alias_method :active_record_on_batches, :build_active_record_enumerator_on_batches
     alias_method :active_record_on_batch_relations, :build_active_record_enumerator_on_batch_relations
     alias_method :throttle, :build_throttle_enumerator
+    alias_method :active_record_on_nested_records, :build_active_record_enumerator_on_nested_records
 
     private
 

--- a/test/unit/active_record_batch_enumerator_test.rb
+++ b/test/unit/active_record_batch_enumerator_test.rb
@@ -122,12 +122,5 @@ module JobIteration
         cursor: cursor,
       )
     end
-
-    def track_queries(&block)
-      queries = []
-      query_cb = ->(*, payload) { queries << payload[:sql] }
-      ActiveSupport::Notifications.subscribed(query_cb, "sql.active_record", &block)
-      queries
-    end
   end
 end

--- a/test/unit/active_record_nested_records_enumerator_test.rb
+++ b/test/unit/active_record_nested_records_enumerator_test.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module JobIteration
+  class ActiveRecordNestedRecordsEnumeratorTest < IterationUnitTest
+    SQL_TIME_FORMAT = "%Y-%m-%d %H:%M:%S.%N"
+
+    attr_reader :described_class
+
+    setup do
+      @described_class = JobIteration::ActiveRecordNestedRecordsEnumerator
+    end
+
+    test "#initialize raises if passed object is not Array" do
+      error = assert_raises(ArgumentError) do
+        described_class.new(:not_array)
+      end
+      assert_equal("relations must be a non-empty Array", error.to_s)
+    end
+
+    test "#initialize raises if passed object is an empty Array" do
+      error = assert_raises(ArgumentError) do
+        described_class.new([])
+      end
+      assert_equal("relations must be a non-empty Array", error.to_s)
+    end
+
+    test "#initialize raises if first relation is not an ActiveRecord::Relation" do
+      error = assert_raises(ArgumentError) do
+        described_class.new([:no_a_relation])
+      end
+      assert_equal("first relation must be an ActiveRecord::Relation", error.to_s)
+    end
+
+    test "#initialize raises if child relations are not Procs" do
+      error = assert_raises(ArgumentError) do
+        described_class.new([Product.all, :not_a_proc])
+      end
+      assert_equal("all child relations must be Procs", error.to_s)
+    end
+
+    test "#each with child relations yields every record with their cursor position" do
+      enum = build_enumerator
+      comment_tuples =
+        Product.includes(:comments).order(:id).take(2)
+          .map { |product| product.comments.sort_by(&:id).map { |comment| [comment, [product.id, comment.id]] } }
+          .flatten(1)
+
+      enum.first(6).each_with_index do |comment_tuple, index|
+        assert_equal comment_tuples[index], comment_tuple
+      end
+    end
+
+    test "#each without child relations yields every record with their cursor position" do
+      enum = build_enumerator(relations: [Product.all])
+      product_tuples = Product.order(:id).take(2).map { |product| [product, [product.id]] }
+
+      enum.first(2).each_with_index do |product_tuple, index|
+        assert_equal product_tuples[index], product_tuple
+      end
+    end
+
+    test "#each doesn't yield anything if the first relation is empty" do
+      enum = build_enumerator(relations: [Product.none])
+      assert_equal([], enum.to_a)
+    end
+
+    test "#each doesn't yield anything if child relation is empty" do
+      enum = build_enumerator(relations: [Product.all, ->(product) { product.comments.none }])
+      assert_equal([], enum.to_a)
+    end
+
+    test "#each raises if child relation is not an ActiveRecord::Relation" do
+      enum = build_enumerator(relations: [Product.all, ->(_product) { :not_a_relation }])
+      error = assert_raises(ArgumentError) do
+        enum.to_a
+      end
+      assert_equal("all child relations must be ActiveRecord::Relations", error.to_s)
+    end
+
+    test "#each yields enumerator when called without a block" do
+      enum = build_enumerator.each
+      assert enum.is_a?(Enumerator)
+    end
+
+    test "batch size is configurable" do
+      enum = build_enumerator(relations: [Product.all, ->(product) { product.comments }], batch_size: 4)
+
+      queries = track_queries do
+        enum.to_a
+      end
+      expected_num_queries =
+        3 + # to get products
+        2 * 10 # to get comments for each product
+
+      assert_equal(expected_num_queries, queries.size)
+    end
+
+    test "columns are configurable" do
+      enum = build_enumerator(columns: [:updated_at])
+      product = Product.first
+      comment = product.comments.order(:updated_at).first
+
+      assert_equal([comment, [product.id, comment.updated_at.strftime(SQL_TIME_FORMAT)]], enum.first)
+    end
+
+    test "columns can be an array" do
+      enum = build_enumerator(columns: [:updated_at, :id])
+      product = Product.first
+      comment = product.comments.order(:updated_at, :id).first
+
+      assert_equal([comment, [product.id, [comment.updated_at.strftime(SQL_TIME_FORMAT), product.id]]], enum.first)
+    end
+
+    test "cursor can be used to resume" do
+      product = Product.first
+      comments = product.comments.order(:id).take(2)
+
+      enum = build_enumerator(cursor: [product.id, comments.first.id])
+
+      assert_equal([comments.second, [product.id, comments.second.id]], enum.first)
+    end
+
+    test "cursor resumes on next record when previous was finished" do
+      product1, product2 = Product.order(:id).take(2)
+
+      enum = build_enumerator(cursor: [product1.id, product1.comments.order(:id).last.id])
+
+      starting_comment = product2.comments.order(:id).first
+      assert_equal([starting_comment, [product2.id, starting_comment.id]], enum.first)
+    end
+
+    private
+
+    def build_enumerator(relations: nil, batch_size: 2, columns: nil, cursor: nil)
+      relations ||= [Product.all, ->(product) { product.comments }]
+      described_class.new(
+        relations,
+        cursor: cursor,
+        columns: columns,
+        batch_size: batch_size
+      )
+    end
+  end
+end


### PR DESCRIPTION
Thank you for this wonderful gem! ❤️ 

Find all the details regarding this feature in the linked issue.

This PR implements:
```ruby
enumerator_builder.active_record_on_nested_records([Shop.all, ->(shop) { shop.products }], cursor: cursor)
enumerator_builder.active_record_on_nested_records([Shop.all, ->(shop) { shop.products }, -> (shop, product) { product.product_variants }], cursor: cursor)
```

This is a PoC to verify the implementation. If everything is ok, would then add missing docs and changelog. 

Closes #63 