### PR TITLE
Silence `dev up` DB creation `met?` check

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -13,7 +13,7 @@ up:
   - custom:
       name: Create Job Iteration database
       meet: mysql -uroot -h job-iteration.railgun -e "CREATE DATABASE job_iteration_test"
-      met?: mysql -uroot -h job-iteration.railgun job_iteration_test -e "SELECT 1"
+      met?: mysql -uroot -h job-iteration.railgun job_iteration_test -e "SELECT 1" &> /dev/null
 
 commands:
   test: bundle exec rake


### PR DESCRIPTION
This silences the output from the `met?` check in the `dev up` database creation task. While the output of the database creation may be useful (in case an error occurs), there is no need to show the output of the check for existence, as only the exit code matters.

<table><thead><tr><th>Database already exists</th><th>Database does not exist</th></tr></thead><tbody><tr><td>

```diff
 $ dev up
 ...
 ⭑ 6/7 Bundler
-1
-1
 ⭑ 7/7 Create Job Iteration database
```

</td><td>

```diff
 $ dev up
 ...
 ⭑ 6/7 Bundler
-ERROR 1049 (42000): Unknown database 'job_iteration_test'
 ┏━━ 👩‍💻  7/7 Create Job Iteration database ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ┃ 𝒾 Create Job Iteration database
 ┃┏━━ Running `(meet) mysql -uroot -h job-iteration.railgun -e "CREATE DATABASE job_iteration_test"` ━━
 ┃┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (0.07s) ━━
-┃ 1
-┃ 1
 ┃ ✓ Create Job Iteration database: done
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
```

</td></tr></tbody></table>