### PR TITLE
Improve dev commands

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+def main
+  begin
+    command = create_command
+  rescue ArgumentError => e
+    abort(e.message)
+  end
+  puts "Running #{command.join(" ")}"
+  system(*command)
+end
+
+def create_command
+  case ARGV.length
+  when 0
+    ["bundle", "exec", "rake", "test"]
+  when 1
+    filename = ARGV[0]
+    ["bundle", "exec", "rake", "test", "TEST=#{filename}"]
+  when 2
+    filename = ARGV[0]
+    test_name = ARGV[1]
+    test_name_with_underscores = test_name.tr(" ", "_")
+    test_name_pattern = "/#{Regexp.escape(test_name_with_underscores)}/"
+    ["bundle", "exec", "rake", "test", "TEST=#{filename}", "TESTOPTS=\"--name=#{test_name_pattern} -v\""]
+  else
+    raise ArgumentError, "Too many arguments. Did you forget to put the test name in quotes?"
+  end
+end
+
+main

--- a/dev.yml
+++ b/dev.yml
@@ -51,3 +51,5 @@ commands:
 
         Example:
         {{command:dev test test/unit/iteration_test.rb version_number}}
+  style:
+    run: bundle exec rubocop -a

--- a/dev.yml
+++ b/dev.yml
@@ -16,4 +16,38 @@ up:
       met?: mysql -uroot -h job-iteration.railgun job_iteration_test -e "SELECT 1" &> /dev/null
 
 commands:
-  test: bundle exec rake
+  test:
+    run:  bin/test "$@"
+    syntax:
+      optional: filename testnamepattern
+    aliases: [t]
+    desc: run tests
+    long_desc: |
+      {{bold:Default}}
+      =======
+      Run the entire test suite.
+
+        Examples:
+        {{command:dev test}}
+        {{command:dev t}}
+
+      {{bold:Run all tests in a file}}
+      ========================
+      Include the file path.
+
+        Example:
+        {{command:dev test test/unit/iteration_test.rb}}
+
+      {{bold:Run a single test in a given file}}
+      ========================
+      Include the file path and the name of the test you'd like to run.
+
+        Example:
+        {{command:dev test test/unit/iteration_test.rb test_that_it_has_a_version_number}}
+
+      {{bold:Run all tests in a given file whose name contains a string}}
+      ========================
+      Include the file path and the string that the test names should contain.
+
+        Example:
+        {{command:dev test test/unit/iteration_test.rb version_number}}


### PR DESCRIPTION
This PR adds more functionality to `dev test` and adds a `dev style` command to run linting.

New options include `dev test test/unit/iteration_test.rb` to run just the tests in that file, and `dev test test/unit/iteration_test.rb test_that_it_has_a_version_number` to run just the single test.

Non-Shopify contributors can use this same functionality by replacing `dev test` with `bin/test`. For example, `bin/test test/unit/iteration_test.rb` runs just the tests in that file.

All of it uses the existing Rake task under the hood, so contributors familiar with that can keep using it.