### PR TITLE
Drop support for ruby 2.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,9 @@ jobs:
         - 6379:6379
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.6, 2.7, 3.0]
         gemfile: [rails_5_2, rails_6_0, rails_edge]
         exclude:
-          - ruby: 2.5
-            gemfile: rails_edge
           - ruby: 2.6
             gemfile: rails_edge
           - ruby: 3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ### Master (unreleased)
+- Drop support for ruby 2.5
 
 ## v1.1.14 (May 28, 2021)
 

--- a/job-iteration.gemspec
+++ b/job-iteration.gemspec
@@ -5,6 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "job-iteration/version"
 
 Gem::Specification.new do |spec|
+  spec.required_ruby_version = ">= 2.6"
   spec.name          = "job-iteration"
   spec.version       = JobIteration::VERSION
   spec.authors       = %w(Shopify)

--- a/lib/job-iteration.rb
+++ b/lib/job-iteration.rb
@@ -38,16 +38,14 @@ module JobIteration
   def load_integrations
     loaded = nil
     INTEGRATIONS.each do |integration|
-      begin
-        load_integration(integration)
-        if loaded
-          raise IntegrationLoadError,
-            "#{loaded} integration has already been loaded, but #{integration} is also available. " \
-            "Iteration will only work with one integration."
-        end
-        loaded = integration
-      rescue LoadError
+      load_integration(integration)
+      if loaded
+        raise IntegrationLoadError,
+          "#{loaded} integration has already been loaded, but #{integration} is also available. " \
+          "Iteration will only work with one integration."
       end
+      loaded = integration
+    rescue LoadError
     end
   end
 


### PR DESCRIPTION
Related to https://github.com/Shopify/job-iteration/issues/102

Ruby 2.5 EOL date was 2021-03-31. We remove support for it and specify `required_ruby_version` in the gemspec.

Since this is a breaking change we would bump the version to `1.2.0` once we release this change.

@Shopify/job-platform
