### PR TITLE
Update rubocop ruby target version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   rubocop-shopify: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4.4
+  TargetRubyVersion: 2.6.5
   Exclude:
     - 'vendor/bundle/**/*'
 Lint/SuppressedException:

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,6 @@ gem "pry"
 gem "mocha"
 
 gem "rubocop-shopify", require: false
-gem "rubocop", "<= 1.12.1", require: false # 1.13.0 drops Ruby 2.4 support
 gem "yard"
 gem "rake"
 

--- a/job-iteration.gemspec
+++ b/job-iteration.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6"
   spec.name          = "job-iteration"
   spec.version       = JobIteration::VERSION
-  spec.authors       = %w(Shopify)
+  spec.authors       = ["Shopify"]
   spec.email         = ["ops-accounts+shipit@shopify.com"]
 
   spec.summary       = "Makes your background jobs interruptible and resumable."
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = %w(lib)
+  spec.require_paths = ["lib"]
 
   spec.metadata["changelog_uri"] = "https://github.com/Shopify/job-iteration/blob/master/CHANGELOG.md"
   spec.metadata["allowed_push_host"] = "https://rubygems.org"

--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -547,13 +547,13 @@ module JobIteration
     end
 
     def test_supports_multiple_job_arguments
-      MultiArgumentIterationJob.perform_later(2, %w(a b c))
+      MultiArgumentIterationJob.perform_later(2, ["a", "b", "c"])
 
       work_one_job
 
       expected = [
-        [0, 2, %w(a b c)],
-        [1, 2, %w(a b c)],
+        [0, 2, ["a", "b", "c"]],
+        [1, 2, ["a", "b", "c"]],
       ]
       assert_equal(expected, MultiArgumentIterationJob.records_performed)
     end

--- a/test/unit/iteration_test.rb
+++ b/test/unit/iteration_test.rb
@@ -246,11 +246,13 @@ class JobIterationTest < IterationUnitTest
 
   def assert_raises_cursor_error(&block)
     error = assert_raises(JobIteration::Iteration::CursorError, &block)
-    inspected_cursor = begin
-                         error.cursor.inspect
-                       rescue NoMethodError
-                         Object.instance_method(:inspect).bind(error.cursor).call
-                       end
+    inspected_cursor =
+      begin
+        error.cursor.inspect
+      rescue NoMethodError
+        Object.instance_method(:inspect).bind(error.cursor).call
+      end
+
     assert_equal(
       "Cursor must be composed of objects capable of built-in (de)serialization: " \
       "Strings, Integers, Floats, Arrays, Hashes, true, false, or nil. " \


### PR DESCRIPTION
Related to https://github.com/Shopify/job-iteration/issues/102

Updated the rubocop target ruby version 

@Shopify/job-platform
