### PR TITLE
Fix enumerator #size for explicit column select

### DIFF
--- a/lib/job-iteration/active_record_batch_enumerator.rb
+++ b/lib/job-iteration/active_record_batch_enumerator.rb
@@ -40,7 +40,7 @@ module JobIteration
     end
 
     def size
-      (@base_relation.count + @batch_size - 1) / @batch_size # ceiling division
+      (@base_relation.count(:all) + @batch_size - 1) / @batch_size # ceiling division
     end
 
     private

--- a/lib/job-iteration/active_record_enumerator.rb
+++ b/lib/job-iteration/active_record_enumerator.rb
@@ -34,7 +34,7 @@ module JobIteration
     end
 
     def size
-      @relation.count
+      @relation.count(:all)
     end
 
     private

--- a/test/unit/active_record_batch_enumerator_test.rb
+++ b/test/unit/active_record_batch_enumerator_test.rb
@@ -48,6 +48,13 @@ module JobIteration
       assert_equal 4, enum.size # 3 batches of 3, 1 batch of 1
     end
 
+    test "#size returns size of the Enumerator with a subset of columns" do
+      enum = build_enumerator(relation: Product.select(:id, :name))
+      assert_equal 5, enum.size # 5 batches of 2
+      enum = build_enumerator(relation: Product.select(:id, :name), batch_size: 3)
+      assert_equal 4, enum.size # 3 batches of 3, 1 batch of 1
+    end
+
     test "batch size is configurable" do
       enum = build_enumerator(batch_size: 4)
       products = Product.order(:id).take(4)

--- a/test/unit/active_record_enumerator_test.rb
+++ b/test/unit/active_record_enumerator_test.rb
@@ -93,6 +93,18 @@ module JobIteration
       assert_equal([shops, cursor], enum.first)
     end
 
+    test "#size returns the number of items in the relation" do
+      enum = build_enumerator(relation: Product.all)
+
+      assert_equal(10, enum.size)
+    end
+
+    test "#size returns the number of items in a relation with a subset of columns" do
+      enum = build_enumerator(relation: Product.select(:id, :name), columns: [:id, :name])
+
+      assert_equal(10, enum.size)
+    end
+
     private
 
     def build_enumerator(relation: Product.all, batch_size: 2, columns: nil, cursor: nil)


### PR DESCRIPTION
Use `count(:all)` instead of [`count`][2] to get the number of items in
a `ActiveRecordEnumerator` and in a `ActiveRecordBatchEnumerator`. This
prevents SQL syntax errors when the relation has an explicit column
selection with `select(:col1, :col2)`, which would attempt to run the
invalid:

```sql
SELECT COUNT(col1, col2) FROM table;
```

Note that this is very similar to what [ActiveRecord::Relation#size][1]
does, without the "smart" logic to return the length of the array of
records already loaded. This keeps the logic in this gem simpler, and
closer to what we had before with regular `count()`.

The issue surfaced [in maintenance_tasks][3], where `#size` is called
for a `ActiveRecordBatchEnumerator` with tasks not defining a custom
`count` method. This would fail for batches selecting a subset of
columns, such as `Product.select(:id, :name).in_batches`


[1]:https://api.rubyonrails.org/classes/ActiveRecord/Relation.html#method-i-size
[2]:https://api.rubyonrails.org/classes/ActiveRecord/Calculations.html#method-i-count
[3]:https://github.com/Shopify/maintenance_tasks/blob/55a5fd3765dd312ba85eaad47b6e8e81feb566a5/app/jobs/concerns/maintenance_tasks/task_job_concern.rb#L107
