### PR TITLE
1.3.2: Defer throttle edge case optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ### Master (unreleased)
 
+- [148](https://github.com/Shopify/job-iteration/pull/148) - Revert "Do not evaluate enumerator when throttled", due to backwards incompatibility.
+
 ## v1.3.1 (Nov 11, 2021)
-- [87](https://github.com/Shopify/job-iteration/pull/87) - Do not evaluate enumerator when throttled
+- [87](https://github.com/Shopify/job-iteration/pull/87) - Do not evaluate enumerator when throttled (REVERTED)
 
 
 ## v1.3.0 (Oct 7, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Master (unreleased)
 
+## v1.3.2 (Nov 12, 2021)
 - [148](https://github.com/Shopify/job-iteration/pull/148) - Revert "Do not evaluate enumerator when throttled", due to backwards incompatibility.
 
 ## v1.3.1 (Nov 11, 2021)

--- a/lib/job-iteration/throttle_enumerator.rb
+++ b/lib/job-iteration/throttle_enumerator.rb
@@ -28,14 +28,14 @@ module JobIteration
 
     def to_enum
       Enumerator.new(-> { @enum.size }) do |yielder|
-        loop do
+        @enum.each do |*val|
           if should_throttle?
             ActiveSupport::Notifications.instrument("throttled.iteration", job_class: @job.class.name)
             @job.retry_job(wait: @backoff)
             throw(:abort, :skip_complete_callbacks)
           end
 
-          yielder.yield(*@enum.next_values)
+          yielder.yield(*val)
         end
       end
     end

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end

--- a/test/unit/throttle_enumerator_test.rb
+++ b/test/unit/throttle_enumerator_test.rb
@@ -125,6 +125,7 @@ module JobIteration
     end
 
     test "does not evaluate enumerator when throttled" do
+      skip("Deferred until 2.0.0")
       CustomizableThrottleJob.perform_now({
         enumerator: Enumerator.new { raise StandardError, "should not evaluate when throttled" },
         throttle_on: -> { true },


### PR DESCRIPTION
**This reverts #87 and bumps the gem version to 1.3.2.**

#87 turns out to break a some things, so we're reverting the change and re-publishing them in 2.0.0.

- Couples `ThrottleEnumerator` to the `Enumerator` API, whereas previously any object responding to .each could be wrapped.
- Checking for throttling before each iteration breaks certain `throttle_on` implementations which rely on being called after each iteration.

See [this Slack discussion](https://shopify.slack.com/archives/C5PBBHH0B/p1636757273235300) for details.

I have left the original test, but skipped it, following the pattern I used in #77.