### PR TITLE
Add test for future enforcement of `Enumerator` class in `ThrottleEnumerator`

### DIFF
--- a/test/unit/throttle_enumerator_test.rb
+++ b/test/unit/throttle_enumerator_test.rb
@@ -132,6 +132,17 @@ module JobIteration
       })
     end
 
+    test "can only wrap another enumerator" do
+      skip("Deferred until 2.0.0")
+      error = assert_raises(ArgumentError) do
+        CustomizableThrottleJob.perform_now({
+          enumerator: [],
+          throttle_on: -> { true },
+        })
+      end
+      assert_equal("wrapped object must be Enumerator, not Array", error.message)
+    end
+
     test "throttle event is instrumented" do
       IterationThrottleJob.should_throttle_sequence = [true]
 


### PR DESCRIPTION
In 2.0.0 we should enforce the class of the object wrapped by `ThrottleEnumerator`, to match our enforcement that `build_enumerator` return
an `Enumerator` object.

## ⚠️ Before Merging
- [x] Rebase after #148 is merged.