### PR TITLE
Batch enumerator preserves relation conditions

### DIFF
--- a/lib/job-iteration/active_record_batch_enumerator.rb
+++ b/lib/job-iteration/active_record_batch_enumerator.rb
@@ -65,7 +65,8 @@ module JobIteration
       @cursor = Array.wrap(cursor)
 
       # Yields relations by selecting the primary keys of records in the batch.
-      # Post.where(published: nil) results in an enumerator of relations like: Post.where(ids: batch_of_ids)
+      # Post.where(published: nil) results in an enumerator of relations like:
+      # Post.where(published: nil, ids: batch_of_ids)
       @base_relation.where(@primary_key => ids)
     end
 

--- a/test/unit/active_record_batch_enumerator_test.rb
+++ b/test/unit/active_record_batch_enumerator_test.rb
@@ -29,6 +29,12 @@ module JobIteration
       refute_predicate relation, :loaded?
     end
 
+    test "#each yields relations that preserve the existing conditions (like ActiveRecord::Batches)" do
+      enum = build_enumerator(relation: Product.where("name LIKE 'lipstick%'"))
+      relation, _ = enum.first
+      assert_includes relation.to_sql, "lipstick"
+    end
+
     test "#each yields enumerator when called without a block" do
       enum = build_enumerator.each
       assert enum.is_a?(Enumerator)


### PR DESCRIPTION
I noticed a mistake in the comment, and I double checked the Active Record behavior.

The relations yielded by BatchEnumerator keep the existing conditions/join on the relation, like [ActiveRecord::Batches does](https://github.com/rails/rails/blob/v6.1.4.1/activerecord/lib/active_record/relation/batches.rb#L237).

I feel like in some cases like joins/includes it may not make sense, but for simple conditions, it's an added security that the impacted records will indeed still respect the requirements.