### PR TITLE
Ignore integrations for YARD

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,4 @@
 --no-private
 --embed-mixins
 --markup markdown
+--exclude lib/job-iteration/integrations/.*


### PR DESCRIPTION
It's started failing with the latest YARD because of/thanks to https://github.com/lsegal/yard/issues/1392

cc @Shopify/rails 