### PR TITLE
Document `throttled.iteration` `ActiveSupport::Notification`

### DIFF
--- a/guides/best-practices.md
+++ b/guides/best-practices.md
@@ -41,6 +41,14 @@ ActiveSupport::Notifications.subscribe('interrupted.iteration') do |_, _, _, _, 
     tags: { job_class: tags[:job_class]&.underscore }
   )
 end
+
+# If you're using ThrottleEnumerator
+ActiveSupport::Notifications.subscribe('throttled.iteration') do |_, _, _, _, tags|
+  StatsD.increment(
+    "iteration.throttled",
+    tags: { job_class: tags[:job_class]&.underscore }
+  )
+end
 ```
 
 ## Max iteration time


### PR DESCRIPTION
The best practices guide mentions all the other instrumentation, so it seems reasonable that it should include the one for `ThrottleEnumerator`, instead of the consumer having to dive into the source code to discover it.

### ⚠️ Before Merging
- [x] Rebase after #162 has been merged