### PR TITLE
Fix YARD documentation error

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,4 +1,3 @@
 --no-private
 --embed-mixins
 --markup markdown
---exclude lib/job-iteration/integrations/.*

--- a/lib/job-iteration/integrations/resque.rb
+++ b/lib/job-iteration/integrations/resque.rb
@@ -10,8 +10,14 @@ module JobIteration
         super
       end
     end
-    # The patch is required in order to call shutdown? on a Resque::Worker instance
-    Resque::Worker.prepend(ResqueIterationExtension)
+
+    # @private
+    module ::Resque
+      class Worker
+        # The patch is required in order to call shutdown? on a Resque::Worker instance
+        prepend(ResqueIterationExtension)
+      end
+    end
 
     JobIteration.interruption_adapter = -> { $resque_worker.try!(:shutdown?) }
   end


### PR DESCRIPTION
This fixes the following error, which is blocking CI (as we use `--fail-on-warning`):

> ```
> [warn]: Load Order / Name Resolution Problem on Resque::Worker:
> -
> Something is trying to call mixins on object Resque::Worker before it has been recognized.
> This error usually means that you need to modify the order in which you parse files
> so that Resque::Worker is parsed before methods or other objects attempt to access it.
> -
> YARD will recover from this error and continue to parse but you *may* have problems
> with your generated documentation. You should probably fix this.
> -
> 
> [error]: Unhandled exception in YARD::Handlers::Ruby::MixinHandler:
>   in `lib/job-iteration/integrations/resque.rb`:14:
> 
> 	14: Resque::Worker.prepend(ResqueIterationExtension)
> 
> [error]: ProxyMethodError: Proxy cannot call method #mixins on object 'Resque::Worker'
> ```

This is the approach documented in https://github.com/lsegal/yard/issues/1353#issuecomment-700188928

What's happening is that YARD thinks Resque::Worker is a constant of ours and is erroring because it's being used before being defined (and documented).

By reopening the class instead, we ensure YARD knows about it, and by using the "@private" magic comment, we ensure YARD doesn't include it in the documentation it generates.

----
Unblocks #161 