### PR TITLE
Fix compatibility with Ruby 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,18 @@ jobs:
         - 6379:6379
     strategy:
       matrix:
-        ruby: [2.6, 2.7, 3.0]
+        ruby: ["2.6", "2.7", "3.0"]
         gemfile: [rails_5_2, rails_6_0, rails_edge]
         exclude:
-          - ruby: 2.6
+          - ruby: "2.6"
             gemfile: rails_edge
-          - ruby: 3.0
+          - ruby: "3.0"
             gemfile: rails_5_2
+        include:
+          - ruby: "3.1"
+            gemfile: rails_edge
+          - ruby: head
+            gemfile: rails_edge
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gemspec
 gem "sidekiq"
 gem "resque"
 
-gem "mysql2", "~> 0.5"
+gem "mysql2", github: "brianmario/mysql2"
 gem "globalid"
 gem "i18n"
 gem "redis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/brianmario/mysql2
+  revision: 25c42c712118b046eb9df7a0f50ffde1a04ee6d1
+  specs:
+    mysql2 (0.5.3)
+
 PATH
   remote: .
   specs:
@@ -42,7 +48,6 @@ GEM
     multi_json (1.15.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    mysql2 (0.5.3)
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
@@ -109,7 +114,7 @@ DEPENDENCIES
   i18n
   job-iteration!
   mocha
-  mysql2 (~> 0.5)
+  mysql2!
   pry
   rake
   redis
@@ -120,4 +125,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.22
+   2.3.5

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -283,7 +283,7 @@ module JobIteration
     def valid_cursor_parameter?(parameters)
       # this condition is when people use the splat operator.
       # def build_enumerator(*)
-      return true if parameters == [[:rest]]
+      return true if parameters == [[:rest]] || parameters == [[:rest, :*]]
 
       parameters.each do |parameter_type, parameter_name|
         next unless parameter_name == :cursor


### PR DESCRIPTION
3.1 and older: `def foo(*) => [[:rest]]`
3.2 and newer: `def foo(*) => [[:rest, :*]]`