### PR TITLE
Fix `Redis.current` deprecation

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -57,6 +57,10 @@ connection_config[:password] = "root" if ENV["CI"]
 
 ActiveRecord::Base.establish_connection(connection_config)
 
+Redis.singleton_class.class_eval do
+  attr_accessor :current
+end
+
 Redis.current = Redis.new(host: host, timeout: 1.0).tap(&:ping)
 
 Resque.redis = Redis.current


### PR DESCRIPTION
`Redis.current` is deprecated which causes a bunch of output in the logs when running the tests.

This fixes it by simply re-defining it, just because I didn't know a better place to store it (global variables are prevented by rubocop).