### PR TITLE
Add Ruby 3.1 and Rails 6.1 and 7 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,20 @@ jobs:
         - 6379:6379
     strategy:
       matrix:
-        ruby: ["2.6", "2.7", "3.0"]
-        gemfile: [rails_5_2, rails_6_0, rails_edge]
+        ruby: ["2.6", "2.7", "3.0", "3.1"]
+        gemfile: [rails_5_2, rails_6_0, rails_6_1, rails_7_0, rails_edge]
         exclude:
+          - ruby: "2.6"
+            gemfile: rails_7_0
           - ruby: "2.6"
             gemfile: rails_edge
           - ruby: "3.0"
             gemfile: rails_5_2
-        include:
           - ruby: "3.1"
-            gemfile: rails_edge
+            gemfile: rails_5_2
+          - ruby: "3.1"
+            gemfile: rails_6_0
+        include:
           - ruby: head
             gemfile: rails_edge
     env:

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+eval_gemfile "../Gemfile"
+
+if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("3.1")
+  gem "net-imap", require: false
+  gem "net-pop", require: false
+  gem "net-smtp", require: false
+end
+
+gem "activejob", "~> 6.1.0"
+gem "activerecord", "~> 6.1.0"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+eval_gemfile "../Gemfile"
+
+gem "activejob", "~> 7.0.0"
+gem "activerecord", "~> 7.0.0"


### PR DESCRIPTION
This PR adds explicit gemfiles for Rails 6.1 and Rails 7.  It updates the Ruby 3.1 configuration to run against these two new entries as well as against Rails edge.