### PR TITLE
Enable per job class `max_job_runtime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [241](https://github.com/Shopify/job-iteration/pull/241) - Require Ruby 2.7+, dropping 2.6 support
 - [241](https://github.com/Shopify/job-iteration/pull/241) - Require Rails 6.0+, dropping 5.2 support
+- [240](https://github.com/Shopify/job-iteration/pull/240) - Allow setting inheritable per-job `job_iteration_max_job_runtime`
 
 ## v1.3.6 (Mar 9, 2022)
 

--- a/guides/best-practices.md
+++ b/guides/best-practices.md
@@ -66,3 +66,18 @@ JobIteration.max_job_runtime = 5.minutes # nil by default
 ```
 
 Use this accessor to tweak how often you'd like the job to interrupt itself.
+
+### Per job max job runtime
+
+For more granular control, `job_iteration_max_job_runtime` can be set **per-job class**. This allows both incremental adoption, as well as using a conservative global setting, and an aggressive setting on a per-job basis.
+
+```ruby
+class MyJob < ApplicationJob
+  include JobIteration::Iteration
+
+  self.job_iteration_max_job_runtime = 3.minutes
+
+  # ...
+```
+
+This setting will be inherited by any child classes, although it can be further overridden. Note that no class can **increase** the `max_job_runtime` it has inherited; it can only be **decreased**. No job can increase its `max_job_runtime` beyond the global limit.

--- a/lib/job-iteration.rb
+++ b/lib/job-iteration.rb
@@ -18,6 +18,15 @@ module JobIteration
   #
   # This setting will make it to always interrupt a job after it's been iterating for 5 minutes.
   # Defaults to nil which means that jobs will not be interrupted except on termination signal.
+  #
+  # This setting can be further reduced (but not increased) by using the inheritable per-class
+  # job_iteration_max_job_runtime setting.
+  # @example
+  #
+  #   class MyJob < ActiveJob::Base
+  #     include JobIteration::Iteration
+  #     self.job_iteration_max_job_runtime = 1.minute
+  #     # ...
   attr_accessor :max_job_runtime
 
   # Used internally for hooking into job processing frameworks like Sidekiq and Resque.

--- a/test/unit/iteration_test.rb
+++ b/test/unit/iteration_test.rb
@@ -251,6 +251,107 @@ class JobIterationTest < IterationUnitTest
     end
   end
 
+  def test_per_class_max_job_runtime_with_default_global
+    freeze_time
+    parent = build_slow_job_class(iterations: 3, iteration_duration: 30.seconds)
+    child = Class.new(parent) do
+      self.job_iteration_max_job_runtime = 1.minute
+    end
+
+    parent.perform_now
+    assert_empty(ActiveJob::Base.queue_adapter.enqueued_jobs)
+
+    child.perform_now
+    assert_partially_completed_job(cursor_position: 2)
+  end
+
+  def test_per_class_max_job_runtime_with_global_set_to_nil
+    freeze_time
+    with_global_max_job_runtime(nil) do
+      parent = build_slow_job_class(iterations: 3, iteration_duration: 30.seconds)
+      child = Class.new(parent) do
+        self.job_iteration_max_job_runtime = 1.minute
+      end
+
+      parent.perform_now
+      assert_empty(ActiveJob::Base.queue_adapter.enqueued_jobs)
+
+      child.perform_now
+      assert_partially_completed_job(cursor_position: 2)
+    end
+  end
+
+  def test_per_class_max_job_runtime_with_global_set
+    freeze_time
+    with_global_max_job_runtime(1.minute) do
+      parent = build_slow_job_class(iterations: 3, iteration_duration: 30.seconds)
+      child = Class.new(parent) do
+        self.job_iteration_max_job_runtime = 30.seconds
+      end
+
+      parent.perform_now
+      assert_partially_completed_job(cursor_position: 2)
+      ActiveJob::Base.queue_adapter.enqueued_jobs = []
+
+      child.perform_now
+      assert_partially_completed_job(cursor_position: 1)
+    end
+  end
+
+  def test_max_job_runtime_cannot_unset_global
+    with_global_max_job_runtime(30.seconds) do
+      klass = Class.new(ActiveJob::Base) do
+        include JobIteration::Iteration
+      end
+
+      error = assert_raises(ArgumentError) do
+        klass.job_iteration_max_job_runtime = nil
+      end
+
+      assert_equal(
+        "job_iteration_max_job_runtime may only decrease; " \
+          "#{klass} tried to increase it from 30 seconds to nil (no limit)",
+        error.message,
+      )
+    end
+  end
+
+  def test_max_job_runtime_cannot_be_higher_than_global
+    with_global_max_job_runtime(30.seconds) do
+      klass = Class.new(ActiveJob::Base) do
+        include JobIteration::Iteration
+      end
+
+      error = assert_raises(ArgumentError) do
+        klass.job_iteration_max_job_runtime = 1.minute
+      end
+
+      assert_equal(
+        "job_iteration_max_job_runtime may only decrease; #{klass} tried to increase it from 30 seconds to 1 minute",
+        error.message,
+      )
+    end
+  end
+
+  def test_max_job_runtime_cannot_be_higher_than_parent
+    with_global_max_job_runtime(1.minute) do
+      parent = Class.new(ActiveJob::Base) do
+        include JobIteration::Iteration
+        self.job_iteration_max_job_runtime = 30.seconds
+      end
+      child = Class.new(parent)
+
+      error = assert_raises(ArgumentError) do
+        child.job_iteration_max_job_runtime = 45.seconds
+      end
+
+      assert_equal(
+        "job_iteration_max_job_runtime may only decrease; #{child} tried to increase it from 30 seconds to 45 seconds",
+        error.message,
+      )
+    end
+  end
+
   private
 
   # Allows building job classes that read max_job_runtime during the test,


### PR DESCRIPTION
This allows incremental adoption of the setting, without applying the setting globally. 

```ruby
JobIteration.max_job_runtime = nil

class ParentJob < ApplicationJob
  include JobIteration::Iteration
  self.max_job_runtime = 5.minutes
  # ...
end
```

Alternatively, it allows applications to set a conservative global setting, and a more aggressive setting per jobs.

```ruby
class ChildJob < ParentJob
  self.max_job_runtime # 5 minutes, inherited
end
class CarefulChildJob < ParentJob
  self.max_job_runtime = 3.minutes # override
end
```

In order to prevent rogue jobs from causing trouble, the per-job override can only be set to a value less than the inherited value.

```ruby
class RogueJob < ParentJob
  self.max_job_runtime = 10.minutes # 💥 ArgumentError
end
class UncleJob < ApplicationJob
  self.max_job_runtime = 10.minutes # ✅ No global default or inherited value, so okay
end
```

### ⚠️ Before Merging
- [x] Clean up commits