### PR TITLE
Investigate using `ActiveJob::Serializers` to serialize cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - [241](https://github.com/Shopify/job-iteration/pull/241) - Require Ruby 2.7+, dropping 2.6 support
 - [241](https://github.com/Shopify/job-iteration/pull/241) - Require Rails 6.0+, dropping 5.2 support
+- [80](https://github.com/Shopify/job-iteration/pull/80) - Deprecate un(de)serializable cursors
+- [80](https://github.com/Shopify/job-iteration/pull/80) - Add `enforce_serializable_cursors` config
 
 ## v1.3.6 (Mar 9, 2022)
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ class MyJob < ApplicationJob
 end
 ```
 
+See [the guide on Custom Enumerators](guides/custom-enumerator.md) for details.
+
 ## Credits
 
 This project would not be possible without these individuals (in alphabetical order):

--- a/guides/custom-enumerator.md
+++ b/guides/custom-enumerator.md
@@ -1,4 +1,8 @@
+# Custom Enumerator
+
 Iteration leverages the [Enumerator](http://ruby-doc.org/core-2.5.1/Enumerator.html) pattern from the Ruby standard library, which allows us to use almost any resource as a collection to iterate.
+
+## Cursorless Enumerator
 
 Consider a custom Enumerator that takes items from a Redis list. Because a Redis List is essentially a queue, we can ignore the cursor:
 
@@ -18,6 +22,8 @@ class ListJob < ActiveJob::Base
   end
 end
 ```
+
+## Enumerator with cursor
 
 But what about iterating based on a cursor? Consider this Enumerator that wraps third party API (Stripe) for paginated iteration:
 
@@ -71,6 +77,74 @@ class StripeJob < ActiveJob::Base
 end
 ```
 
+## Notes
+
 We recommend that you read the implementation of the other enumerators that come with the library (`CsvEnumerator`, `ActiveRecordEnumerator`) to gain a better understanding of building Enumerator objects.
 
+### Post-`yield` code
+
 Code that is written after the `yield` in a custom enumerator is not guaranteed to execute. In the case that a job is forced to exit ie `job_should_exit?` is true, then the job is re-enqueued during the yield and the rest of the code in the enumerator does not run. You can follow that logic [here](https://github.com/Shopify/job-iteration/blob/9641f455b9126efff2214692c0bef423e0d12c39/lib/job-iteration/iteration.rb#L128-L131).
+
+### Cursor types
+
+To ensure cursors are not corrupted, they should only be composed of classes Ruby's JSON library can safely serialize and de-serialize. These are:
+
+- `Array`
+- `Hash`
+- `String`
+- `Integer`
+- `Float`
+- `TrueClass` (`true`)
+- `FalseClass` (`false`)
+- `NilClass` (`nil`)
+
+For example, if a `Time` object is given as a cursor (perhaps we are iterating over API resources by creation time), it will be serialized by the job adapter, which typically calls `to_s`, meaning upon resumption the job will unexpectedly get receive a String as cursor instead of the original `Time` object.
+
+```ruby
+require "time"
+class APIJob < ActiveJob::Base
+  include JobIteration::Iteration
+
+  def build_enumerator(cursor:)
+    Enumerator.new do |yielder|
+      build_stream(cursor).each do |item|
+        yielder.yield item, item.created_at
+      end
+    end
+  end
+
+  def each_iteration(item_from_api)
+    # ...
+  end
+
+  private
+
+  def build_stream(cursor)
+    return SomeAPI.stream if cursor.nil?
+
+    SomeAPI.stream(since: cursor) # 💥 ArgumentError from API
+  end
+end
+```
+
+Instead, the job should take steps to serialize and deserialize the cursor as an object of a safe class (e.g. `String`):
+
+```diff
+   def build_enumerator(cursor:)
+     Enumerator.new do |yielder|
+       build_stream(cursor).each do |item|
+-        yielder.yield item, item.created_at
++        yielder.yield item, item.created_at.iso8601(6)
+       end
+     end
+   end
+```
+
+```diff
+   def build_stream(cursor)
+     return SomeAPI.stream if cursor.nil?
+
+-    SomeAPI.stream(since: cursor) # 💥 ArgumentError from API
++    SomeAPI.stream(since: Time.iso8601(cursor))
+   end
+```

--- a/guides/custom-enumerator.md
+++ b/guides/custom-enumerator.md
@@ -148,3 +148,5 @@ Instead, the job should take steps to serialize and deserialize the cursor as an
 +    SomeAPI.stream(since: Time.iso8601(cursor))
    end
 ```
+
+Use of unsupported classes is deprecated, and will raise an error in a future version of Job Iteration.

--- a/guides/custom-enumerator.md
+++ b/guides/custom-enumerator.md
@@ -98,7 +98,7 @@ To ensure cursors are not corrupted, they should only be composed of classes Rub
 - `FalseClass` (`false`)
 - `NilClass` (`nil`)
 
-For example, if a `Time` object is given as a cursor (perhaps we are iterating over API resources by creation time), it will be serialized by the job adapter, which typically calls `to_s`, meaning upon resumption the job will unexpectedly get receive a String as cursor instead of the original `Time` object.
+For example, if a `Time` object is given as a cursor (perhaps we are iterating over API resources by creation time), it will be serialized by the job adapter, which typically calls `to_s`, meaning upon resumption the job will unexpectedly receive a String as cursor instead of the original `Time` object.
 
 ```ruby
 require "time"

--- a/lib/job-iteration.rb
+++ b/lib/job-iteration.rb
@@ -33,7 +33,7 @@ module JobIteration
   #
   #     class MyJob < ActiveJob::Base
   #       include JobIteration::Iteration
-  #       self.enforce_serializable_cursors = false
+  #       self.job_iteration_enforce_serializable_cursors = false
   #       # ...
   #     end
   #

--- a/lib/job-iteration.rb
+++ b/lib/job-iteration.rb
@@ -9,6 +9,8 @@ module JobIteration
 
   INTEGRATIONS = [:resque, :sidekiq]
 
+  Deprecation = ActiveSupport::Deprecation.new("2.0", "JobIteration")
+
   extend self
 
   # Use this to _always_ interrupt the job after it's been running for more than N seconds.
@@ -19,6 +21,25 @@ module JobIteration
   # This setting will make it to always interrupt a job after it's been iterating for 5 minutes.
   # Defaults to nil which means that jobs will not be interrupted except on termination signal.
   attr_accessor :max_job_runtime
+
+  # Set this to `true` to enforce that cursors be composed of objects capable
+  # of built-in (de)serialization: Strings, Integers, Floats, Arrays, Hashes,
+  # true, false, or nil.
+  #
+  #    JobIteration.enforce_serializable_cursors = true
+  #
+  # For more granular control, this can also be configured per job class, and
+  # is inherited by child classes.
+  #
+  #     class MyJob < ActiveJob::Base
+  #       include JobIteration::Iteration
+  #       self.enforce_serializable_cursors = false
+  #       # ...
+  #     end
+  #
+  # Note that non-enforcement is deprecated and enforcement will be mandatory
+  # in version 2.0, at which point this config will go away.
+  attr_accessor :enforce_serializable_cursors
 
   # Used internally for hooking into job processing frameworks like Sidekiq and Resque.
   attr_accessor :interruption_adapter

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -19,7 +19,7 @@ module JobIteration
       define_callbacks :complete
 
       class_attribute(
-        :enforce_serializable_cursors,
+        :job_iteration_enforce_serializable_cursors,
         instance_writer: false,
         instance_predicate: false,
         default: JobIteration.enforce_serializable_cursors,
@@ -224,7 +224,7 @@ module JobIteration
         "Cursor must be composed of objects capable of built-in (de)serialization: " \
           "Strings, Integers, Floats, Arrays, Hashes, true, false, or nil.",
         cursor: cursor,
-      ) if enforce_serializable_cursors
+      ) if job_iteration_enforce_serializable_cursors
 
       Deprecation.warn(<<~DEPRECATION_MESSAGE)
         The Enumerator returned by #{self.class.name}#build_enumerator yielded a cursor which is unsafe to serialize.

--- a/test/unit/iteration_test.rb
+++ b/test/unit/iteration_test.rb
@@ -256,7 +256,7 @@ class JobIterationTest < IterationUnitTest
   def test_jobs_using_unserializable_cursor_will_raise_if_enforce_serializable_cursors_set_per_class
     with_global_enforce_serializable_cursors(false) do
       job_class = build_invalid_cursor_job(cursor: :unserializable)
-      job_class.enforce_serializable_cursors = true
+      job_class.job_iteration_enforce_serializable_cursors = true
 
       assert_raises_cursor_error do
         job_class.perform_now
@@ -267,7 +267,7 @@ class JobIterationTest < IterationUnitTest
   def test_jobs_using_unserializable_cursor_will_raise_if_enforce_serializable_cursors_set_in_parent
     with_global_enforce_serializable_cursors(false) do
       parent = build_invalid_cursor_job(cursor: :unserializable)
-      parent.enforce_serializable_cursors = true
+      parent.job_iteration_enforce_serializable_cursors = true
       child = Class.new(parent)
 
       assert_raises_cursor_error do
@@ -279,7 +279,7 @@ class JobIterationTest < IterationUnitTest
   def test_jobs_using_unserializable_cursor_will_not_raise_if_enforce_serializable_cursors_unset_per_class
     with_global_enforce_serializable_cursors(true) do
       job_class = build_invalid_cursor_job(cursor: :unserializable)
-      job_class.enforce_serializable_cursors = false
+      job_class.job_iteration_enforce_serializable_cursors = false
 
       assert_nothing_raised do
         job_class.perform_now


### PR DESCRIPTION
This investigates an alternate approach to #81, as suggested by @bdewater.

If this approach makes sense, #81 will be updated and this PR will be closed.
If not, then it will also be closed.