### PR TITLE
Fix ConditionNotSupportedError raise

### DIFF
--- a/lib/job-iteration/active_record_batch_enumerator.rb
+++ b/lib/job-iteration/active_record_batch_enumerator.rb
@@ -26,7 +26,7 @@ module JobIteration
       end
 
       if relation.arel.orders.present? || relation.arel.taken.present?
-        raise ConditionNotSupportedError
+        raise JobIteration::ActiveRecordCursor::ConditionNotSupportedError
       end
 
       @base_relation = relation.reorder(@columns.join(","))

--- a/test/unit/active_record_batch_enumerator_test.rb
+++ b/test/unit/active_record_batch_enumerator_test.rb
@@ -125,6 +125,12 @@ module JobIteration
       assert_equal expected_num_queries, queries.size
     end
 
+    test "enumerator will raise ConditionNotSupportedError if the relation is ordered" do
+      assert_raise(JobIteration::ActiveRecordCursor::ConditionNotSupportedError) do
+        build_enumerator(relation: Product.order(created_at: :desc))
+      end
+    end
+
     private
 
     def build_enumerator(relation: Product.all, batch_size: 2, columns: nil, cursor: nil)


### PR DESCRIPTION
This constant does not exist in this scope. Running the test in the PR without the associated code change results in: "uninitialized constant JobIteration::ActiveRecordBatchEnumerator::ConditionNotSupportedError"