### PR TITLE
Replace DatabaseCleaner with Active Record to truncate tables

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "mysql2", github: "brianmario/mysql2"
 gem "globalid"
 gem "i18n"
 gem "redis"
-gem "database_cleaner"
 
 gem "pry"
 gem "mocha"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,12 +30,6 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     connection_pool (2.2.5)
-    database_cleaner (2.0.1)
-      database_cleaner-active_record (~> 2.0.0)
-    database_cleaner-active_record (2.0.1)
-      activerecord (>= 5.a)
-      database_cleaner-core (~> 2.0.0)
-    database_cleaner-core (2.0.1)
     globalid (1.0.0)
       activesupport (>= 5.0)
     i18n (1.12.0)
@@ -108,7 +102,6 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
-  database_cleaner
   globalid
   i18n
   job-iteration!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,7 +15,6 @@ require "active_job"
 require "active_record"
 require "pry"
 require "mocha/minitest"
-require "database_cleaner"
 
 GlobalID.app = "iteration"
 ActiveRecord::Base.include(GlobalID::Identification) # https://github.com/rails/globalid/blob/main/lib/global_id/railtie.rb
@@ -74,8 +73,6 @@ ActiveRecord::Base.connection.create_table(Product.table_name, force: true) do |
   t.timestamps
 end
 
-DatabaseCleaner.strategy = :truncation
-
 module LoggingHelpers
   def assert_logged(message)
     old_logger = ActiveJob::Base.logger
@@ -117,12 +114,16 @@ class IterationUnitTest < ActiveSupport::TestCase
 
   teardown do
     ActiveJob::Base.queue_adapter.enqueued_jobs = []
-    DatabaseCleaner.clean
+    truncate_fixtures
   end
 
   def insert_fixtures
     10.times do |n|
       Product.create!(name: "lipstick #{n}")
     end
+  end
+
+  def truncate_fixtures
+    ActiveRecord::Base.connection.truncate(Product.table_name)
   end
 end


### PR DESCRIPTION
Fixes CI as noted in https://github.com/Shopify/job-iteration/pull/81#issuecomment-1298085113 cc @sambostock 