### PR TITLE
Support nested iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Master (unreleased)
 
+- [295](https://github.com/Shopify/job-iteration/pull/295) - Support nested iteration
 - [241](https://github.com/Shopify/job-iteration/pull/241) - Require Ruby 2.7+, dropping 2.6 support
 - [241](https://github.com/Shopify/job-iteration/pull/241) - Require Rails 6.0+, dropping 5.2 support
 - [240](https://github.com/Shopify/job-iteration/pull/240) - Allow setting inheritable per-job `job_iteration_max_job_runtime`

--- a/README.md
+++ b/README.md
@@ -130,6 +130,27 @@ class CsvJob < ApplicationJob
 end
 ```
 
+```ruby
+class NestedIterationJob < ApplicationJob
+  include JobIteration::Iteration
+
+  def build_enumerator(cursor:)
+    enumerator_builder.nested(
+      [
+        ->(cursor) { enumerator_builder.active_record_on_records(Shop.all, cursor: cursor) },
+        ->(shop, cursor) { enumerator_builder.active_record_on_records(shop.products, cursor: cursor) },
+        ->(_shop, product, cursor) { enumerator_builder.active_record_on_batch_relations(product.product_variants, cursor: cursor) }
+      ],
+      cursor: cursor
+    )
+  end
+
+  def each_iteration(product_variants_relation)
+    # do something
+  end
+end
+```
+
 Iteration hooks into Sidekiq and Resque out of the box to support graceful interruption. No extra configuration is required.
 
 ## Guides

--- a/lib/job-iteration/nested_enumerator.rb
+++ b/lib/job-iteration/nested_enumerator.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module JobIteration
+  # @private
+  class NestedEnumerator
+    def initialize(enums, cursor: nil)
+      unless enums.all?(Proc)
+        raise ArgumentError, "enums must contain only procs/lambdas"
+      end
+
+      if cursor && enums.size != cursor.size
+        raise ArgumentError, "cursor should have one item per enum"
+      end
+
+      @enums = enums
+      @cursor = cursor || Array.new(enums.size)
+    end
+
+    def each(&block)
+      return to_enum unless block_given?
+
+      iterate([], [], 0, &block)
+    end
+
+    private
+
+    def iterate(current_items, current_cursor, index, &block)
+      cursor = @cursor[index]
+      enum = @enums[index].call(*current_items, cursor)
+
+      enum.each do |item, cursor_value|
+        if index == @cursor.size - 1
+          yield item, current_cursor + [cursor_value]
+        else
+          iterate(current_items + [item], current_cursor + [cursor_value], index + 1, &block)
+        end
+      end
+    end
+  end
+end

--- a/test/unit/enumerator_builder_test.rb
+++ b/test/unit/enumerator_builder_test.rb
@@ -60,6 +60,20 @@ module JobIteration
       enumerator_builder(wraps: 0).build_csv_enumerator(CSV.new("test"), cursor: nil)
     end
 
+    test_builder_method(:build_nested_enumerator) do
+      enumerator_builder(wraps: 0).build_nested_enumerator(
+        [
+          ->(cursor) {
+            enumerator_builder.build_active_record_enumerator_on_records(Product.all, cursor: cursor)
+          },
+          ->(product, cursor) {
+            enumerator_builder.build_active_record_enumerator_on_records(product.comments, cursor: cursor)
+          },
+        ],
+        cursor: nil,
+      )
+    end
+
     # checks that all the non-alias methods were tested
     raise "methods not tested: #{methods.inspect}" unless methods.empty?
 

--- a/test/unit/nested_enumerator_test.rb
+++ b/test/unit/nested_enumerator_test.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module JobIteration
+  class NestedEnumeratorTest < IterationUnitTest
+    test "accepts only callables as enums" do
+      error = assert_raises(ArgumentError) do
+        build_enumerator(outer: [[1, 2, 3].each])
+      end
+      assert_equal("enums must contain only procs/lambdas", error.message)
+    end
+
+    test "raises when cursor is not of the same size as enums" do
+      error = assert_raises(ArgumentError) do
+        build_enumerator(cursor: [Product.first.id])
+      end
+      assert_equal("cursor should have one item per enum", error.message)
+    end
+
+    test "yields enumerator when called without a block" do
+      enum = build_enumerator
+      assert enum.is_a?(Enumerator)
+      assert_nil enum.size
+    end
+
+    test "yields every nested record with their cursor position" do
+      enum = build_enumerator
+
+      products = Product.includes(:comments).order(:id).take(3)
+      comments = products.map do |product|
+        product.comments.sort_by(&:id).map { |comment| [comment, [product.id, comment.id]] }
+      end.flatten(1)
+
+      enum.each_with_index do |(comment, cursor), index|
+        expected_comment, expected_cursor = comments[index]
+        assert_equal(expected_comment, comment)
+        assert_equal(expected_cursor, cursor)
+      end
+    end
+
+    test "cursor can be used to resume" do
+      enum = build_enumerator
+      _first_comment, first_cursor = enum.next
+      second_comment, second_cursor = enum.next
+
+      enum = build_enumerator(cursor: first_cursor)
+      assert_equal([second_comment, second_cursor], enum.first)
+    end
+
+    test "doesn't yield anything if contains empty enum" do
+      enum = ->(cursor, _product) { records_enumerator(Comment.none, cursor: cursor) }
+      enum = build_enumerator(inner: enum)
+      assert_empty(enum.to_a)
+    end
+
+    test "works with single level nesting" do
+      enum = build_enumerator(inner: nil)
+      products = Product.order(:id).to_a
+
+      enum.each_with_index do |(product, cursor), index|
+        assert_equal(products[index], product)
+        assert_equal([products[index].id], cursor)
+      end
+    end
+
+    private
+
+    def build_enumerator(
+      outer: ->(cursor) { records_enumerator(Product.all, cursor: cursor) },
+      inner: ->(product, cursor) { records_enumerator(product.comments, cursor: cursor) },
+      cursor: nil
+    )
+      NestedEnumerator.new([outer, inner].compact, cursor: cursor).each
+    end
+
+    def records_enumerator(scope, cursor: nil)
+      ActiveRecordEnumerator.new(scope, cursor: cursor).records
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/Shopify/job-iteration/issues/63.
This is a generalized version of https://github.com/Shopify/job-iteration/pull/100, as suggested in https://github.com/Shopify/job-iteration/issues/63#issuecomment-1150021343.

Example usage:
```ruby
class NestedIterationJob < ApplicationJob
  include JobIteration::Iteration

  def build_enumerator(cursor:)
    enumerator_builder.nested(
      [
        ->(cursor) { enumerator_builder.active_record_on_records(Shop.all, cursor: cursor) },
        ->(shop, cursor) { enumerator_builder.active_record_on_records(shop.products, cursor: cursor) },
        ->(_shop, product, cursor) { enumerator_builder.active_record_on_batch_relations(product.product_variants, cursor: cursor) }
      ],
      cursor: cursor
    )
  end

  def each_iteration(product_variants_relation)
    # do something
  end
end
```

cc @bdewater 