### PR TITLE
Add total_time and start_time description. 

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -7,7 +7,7 @@ module JobIteration
     extend ActiveSupport::Concern
 
     attr_accessor(
-      :cursor_position
+      :cursor_position,
       :times_interrupted
     )
 

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -8,7 +8,7 @@ module JobIteration
 
     attr_accessor(
       :cursor_position,
-      :times_interrupted
+      :times_interrupted,
     )
 
     # The time where the job starts running. If the job is interrupted and runs again, the value is updated.

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -11,11 +11,11 @@ module JobIteration
       :times_interrupted,
     )
 
-    # The time where the job starts running. If the job is interrupted and runs again, the value is updated.
+    # The time when the job starts running. If the job is interrupted and runs again, the value is updated.
     attr_accessor :start_time
 
-    # The total time the job has been performing including multiple iterations.
-    # The time isn't reset if the job is interrupted. 
+    # The total time the job has been running, including multiple iterations.
+    # The time isn't reset if the job is interrupted.
     attr_accessor :total_time
 
     class CursorError < ArgumentError

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -7,11 +7,16 @@ module JobIteration
     extend ActiveSupport::Concern
 
     attr_accessor(
-      :cursor_position,
-      :start_time,
-      :times_interrupted,
-      :total_time,
+      :cursor_position
+      :times_interrupted
     )
+
+    # The time where the job starts running. If the job is interrupted and runs again, the value is updated.
+    attr_accessor :start_time
+
+    # The total time the job has been performing including multiple iterations.
+    # The time isn't reset if the job is interrupted. 
+    attr_accessor :total_time
 
     class CursorError < ArgumentError
       attr_reader :cursor


### PR DESCRIPTION
I added descriptions for the attributes `total_time` and `start_time`. It wasn't clear to me whether they account for when the job is interrupted/throttled/killed or not. 

As a next step, it'd be great to add Rubydocs to the gem and more documentation to the public attributes & methods. 