### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,16 @@ jobs:
         - 6379:6379
     strategy:
       matrix:
-        ruby: ["2.7", "3.0", "3.1"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
         gemfile: [rails_6_0, rails_6_1, rails_7_0, rails_edge]
         exclude:
           - ruby: "3.1"
             gemfile: rails_6_0
+          - ruby: "3.2"
+            gemfile: rails_6_0
+          - ruby: "3.2"
+            gemfile: rails_6_1        
+
         include:
           - ruby: head
             gemfile: rails_edge

--- a/lib/job-iteration/csv_enumerator.rb
+++ b/lib/job-iteration/csv_enumerator.rb
@@ -41,7 +41,7 @@ module JobIteration
     def batches(batch_size:, cursor:)
       @csv.lazy
         .each_slice(batch_size)
-        .each_with_index
+        .with_index
         .drop(count_of_processed_rows(cursor))
         .to_enum { (count_of_rows_in_file.to_f / batch_size).ceil }
     end


### PR DESCRIPTION
Addressed a lint to get Rubocop to run green.

Everything runs green on my fork.