### PR TITLE
Use ActiveSupport::Notifications and LogSubscriber for customizing log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [241](https://github.com/Shopify/job-iteration/pull/241) - Require Rails 6.0+, dropping 5.2 support
 - [240](https://github.com/Shopify/job-iteration/pull/240) - Allow setting inheritable per-job `job_iteration_max_job_runtime`
 - [289](https://github.com/Shopify/job-iteration/pull/289) - Fix uninitialized constant error when raising `ConditionNotSupportedError` from `ActiveRecordBatchEnumerator`
+- [338](https://github.com/Shopify/job-iteration/pull/338) - All logs are now `ActiveSupport::Notifications` events and logged using `ActiveSupport::LogSubscriber` to allow customization. Events now always include the `cursor_position` tag.
 - [341](https://github.com/Shopify/job-iteration/pull/341) - Add `JobIteration.default_retry_backoff`, which sets a default delay when jobs are re-enqueued after being interrupted. Defaults to `nil`, meaning no delay, which matches the current behaviour.
 
 ## v1.3.6 (Mar 9, 2022)

--- a/lib/job-iteration.rb
+++ b/lib/job-iteration.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require "active_job"
 require_relative "./job-iteration/version"
 require_relative "./job-iteration/enumerator_builder"
 require_relative "./job-iteration/iteration"
+require_relative "./job-iteration/log_subscriber"
 
 module JobIteration
   IntegrationLoadError = Class.new(StandardError)
@@ -10,6 +12,10 @@ module JobIteration
   INTEGRATIONS = [:resque, :sidekiq]
 
   extend self
+
+  attr_accessor :logger
+
+  self.logger = ActiveJob::Base.logger
 
   # Use this to _always_ interrupt the job after it's been running for more than N seconds.
   # @example

--- a/lib/job-iteration/log_subscriber.rb
+++ b/lib/job-iteration/log_subscriber.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module JobIteration
+  class LogSubscriber < ActiveSupport::LogSubscriber
+    def logger
+      JobIteration.logger
+    end
+
+    def nil_enumerator(event)
+      info do
+        "[JobIteration::Iteration] `build_enumerator` returned nil. Skipping the job."
+      end
+    end
+
+    def not_found(event)
+      info do
+        "[JobIteration::Iteration] Enumerator found nothing to iterate! " \
+          "times_interrupted=#{event.payload[:times_interrupted]} cursor_position=#{event.payload[:cursor_position]}"
+      end
+    end
+
+    def interrupted(event)
+      info do
+        "[JobIteration::Iteration] Interrupting and re-enqueueing the job " \
+          "cursor_position=#{event.payload[:cursor_position]}"
+      end
+    end
+
+    def completed(event)
+      info do
+        message = "[JobIteration::Iteration] Completed iterating. times_interrupted=%d total_time=%.3f"
+        Kernel.format(message, event.payload[:times_interrupted], event.payload[:total_time])
+      end
+    end
+  end
+end
+
+JobIteration::LogSubscriber.attach_to(:iteration)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,9 +75,9 @@ end
 
 module LoggingHelpers
   def assert_logged(message)
-    old_logger = ActiveJob::Base.logger
+    old_logger = JobIteration.logger
     log = StringIO.new
-    ActiveJob::Base.logger = Logger.new(log)
+    JobIteration.logger = Logger.new(log)
 
     begin
       yield
@@ -85,12 +85,12 @@ module LoggingHelpers
       log.rewind
       assert_match(message, log.read)
     ensure
-      ActiveJob::Base.logger = old_logger
+      JobIteration.logger = old_logger
     end
   end
 end
 
-ActiveJob::Base.logger = Logger.new(IO::NULL)
+JobIteration.logger = Logger.new(IO::NULL)
 
 module ActiveSupport
   class TestCase


### PR DESCRIPTION
This is the [same mechanism](https://api.rubyonrails.org/classes/ActiveSupport/LogSubscriber.html) Rails uses to output logs from events. This allows for more instrumentation and easier customization of log output. The default log output is completely unchanged.

Since a bunch of events need `cursor_position` to keep the existing logging, I made it a default tag for all events.

Edit: closes https://github.com/Shopify/job-iteration/pull/40 by including it in an updated way.