### PR TITLE
Continue other jobs on Rails edge failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }} | Gemfile ${{ matrix.gemfile }}
+    continue-on-error: ${{ matrix.gemfile == 'rails_edge' }}
     services:
       redis:
         image: redis


### PR DESCRIPTION
Rails edge (and Ruby HEAD, but we always combine that with Rails edge) is a moving target out of our control. Therefore, if a failure occurs on a job testing against it, it is useful to let the other jobs continue, as that helps narrow down if the failure is due to a change made there.

I noticed that CI was failing on #81, but couldn't tell if it was isolated to edge versions because the jobs would get cancelled. Sure enough, it looks like something has broken upstream.