### PR TITLE
Adjust total time for failed jobs

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -197,9 +197,9 @@ module JobIteration
           "times_interrupted=#{times_interrupted} cursor_position=#{cursor_position}",
       ) unless found_record
 
-      adjust_total_time
-
       true
+    ensure
+      adjust_total_time
     end
 
     def record_unit_of_work(&block)


### PR DESCRIPTION
This PR ensures that `total_time` is always going to be updated, even when a job fails.

Previously, if a job failed, `total_time` would not include the run-time of the iteration that threw the exception.

**Motivation**
We want to create a metric to keep track of a job's total run-time. This metric is going to be reported whenever a job completes successfully, fails, or is interrupted