### PR TITLE
[doc] Document argument passing semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Iteration hooks into Sidekiq and Resque out of the box to support graceful inter
 ## Guides
 
 * [Iteration: how it works](guides/iteration-how-it-works.md)
+* [Job argument semantics](guides/argument-semantics.md)
 * [Best practices](guides/best-practices.md)
 * [Writing custom enumerator](guides/custom-enumerator.md)
 * [Throttling](guides/throttling.md)

--- a/guides/argument-semantics.md
+++ b/guides/argument-semantics.md
@@ -23,7 +23,7 @@ class ArglessJob < ActiveJob::Base
   end
 end
 
-To spool the job:
+To enqueue the job:
 
 ```ruby
 ArglessJob.perform_later
@@ -47,7 +47,7 @@ class ArgumentativeJob < ActiveJob::Base
 end
 ```
 
-To spool the job:
+To enqueue the job:
 
 ```ruby
 Argumentative.perform_later(_arg1 = "One", _arg2 = "Two", _arg3 = "Three")
@@ -75,7 +75,7 @@ class ParameterizedJob < ActiveJob::Base
 end
 ```
 
-To spool the job:
+To enqueue the job:
 
 ```ruby
 ParameterizedJob.perform_later(name: "Jane", email: "jane@host.example")
@@ -105,7 +105,7 @@ class HighlyConfigurableGreetingJob < ActiveJob::Base
 end
 ```
 
-To spool the job:
+To enqueue the job:
 
 ```ruby
 HighlyConfigurableGreetingJob.perform_later(_subject_line = "Greetings everybody!", sender_name: "Jane", sender_email: "jane@host.example")

--- a/guides/argument-semantics.md
+++ b/guides/argument-semantics.md
@@ -50,7 +50,7 @@ end
 To enqueue the job:
 
 ```ruby
-Argumentative.perform_later(_arg1 = "One", _arg2 = "Two", _arg3 = "Three")
+ArgumentativeJob.perform_later(_arg1 = "One", _arg2 = "Two", _arg3 = "Three")
 ```
 
 ### Jobs with keyword arguments

--- a/guides/argument-semantics.md
+++ b/guides/argument-semantics.md
@@ -1,0 +1,114 @@
+`job-iteration` overrides the `perform` method of `ActiveJob::Base` to allow for iteration. The `perform` method preserves all the standard calling conventions of the original, but the way the subsequent methods work might differ from what one expects from an ActiveJob subclass.
+
+The call sequence is usually 3 methods:
+
+`perform -> build_enumerator -> each_iteration|each_batch`
+
+In that sense `job-iteration` works more like a framework (it calls your code) than like library (that you would call). When using jobs with parameters, the following rules of thumb are good to keep in mind.
+
+### Jobs without arguments
+
+Jobs without arguments do not pass anything into either `build_enumerator` or `each_iteration` except for the `cursor` which `job-iteration` persists by itself:
+
+```ruby
+class ArglessJob < ActiveJob::Base
+  include JobIteration::Iteration
+
+  def build_enumerator(cursor:)
+    # ...
+  end
+
+  def each_iteration(single_object_yielded_from_enumerator)
+    # ...
+  end
+end
+
+To spool the job:
+
+```ruby
+ArglessJob.perform_later
+```
+
+### Jobs with positional arguments
+
+Jobs with positional arguments will have those arguments available to both `build_enumerator` and `each_iteration`:
+
+```ruby
+class ArgumentativeJob < ActiveJob::Base
+  include JobIteration::Iteration
+
+  def build_enumerator(arg1, arg2, arg3, cursor:)
+    # ...
+  end
+
+  def each_iteration(single_object_yielded_from_enumerator, arg1, arg2, arg3)
+    # ...
+  end
+end
+```
+
+To spool the job:
+
+```ruby
+Argumentative.perform_later(_arg1 = "One", _arg2 = "Two", _arg3 = "Three")
+```
+
+### Jobs with keyword arguments
+
+Jobs with keyword arguments will have the keyword arguments available to both `build_enumerator` and `each_iteration`, but these arguments come packaged into a Hash in both cases. You will need to `fetch` or `[]` your parameter from the `Hash` you get passed in:
+
+```ruby
+class ParameterizedJob < ActiveJob::Base
+  include JobIteration::Iteration
+
+  def build_enumerator(kwargs, cursor:)
+    name = kwargs.fetch(:name)
+    email = kwargs.fetch(:email)
+    # ...
+  end
+
+  def each_iteration(object_yielded_from_enumerator, kwargs)
+    name = kwargs.fetch(:name)
+    email = kwargs.fetch(:email)
+    # ...
+  end
+end
+```
+
+To spool the job:
+
+```ruby
+ParameterizedJob.perform_later(name: "Jane", email: "jane@host.example")
+```
+
+Note that you cannot use `ruby2_keywords` at present.
+
+### Jobs with both positional and keyword arguments
+
+Jobs with keyword arguments will have the keyword arguments available to both `build_enumerator` and `each_iteration`, but these arguments come packaged into a Hash in both cases. You will need to `fetch` or `[]` your parameter from the `Hash` you get passed in:
+
+```ruby
+class HighlyConfigurableGreetingJob < ActiveJob::Base
+  include JobIteration::Iteration
+
+  def build_enumerator(subject_line, kwargs, cursor:)
+    name = kwargs.fetch(:sender_name)
+    email = kwargs.fetch(:sender_email)
+    # ...
+  end
+
+  def each_iteration(subject_line, kwargs)
+    name = kwargs.fetch(:sender_name)
+    email = kwargs.fetch(:sender_email)
+    # ...
+  end
+end
+```
+
+To spool the job:
+
+```ruby
+HighlyConfigurableGreetingJob.perform_later(_subject_line = "Greetings everybody!", sender_name: "Jane", sender_email: "jane@host.example")
+```
+
+Note that you cannot use `ruby2_keywords` at present.

--- a/guides/argument-semantics.md
+++ b/guides/argument-semantics.md
@@ -82,11 +82,11 @@ To enqueue the job:
 ParameterizedJob.perform_later(name: "Jane", email: "jane@host.example")
 ```
 
-Note that you cannot use `ruby2_keywords` at present.
+Note that you cannot use `ruby2_keywords` at present, and the keyword arguments syntax is not supported in `each_iteration` / `build_enumerator`.
 
 ### Jobs with both positional and keyword arguments
 
-Jobs with keyword arguments will have the keyword arguments available to both `build_enumerator` and `each_iteration`, but these arguments come packaged into a Hash in both cases. You will need to `fetch` or `[]` your parameter from the `Hash` you get passed in:
+Jobs with keyword arguments will have the keyword arguments available to both `build_enumerator` and `each_iteration`, but these arguments come packaged into a Hash in both cases. You will need to `fetch` or `[]` your parameter from the `Hash` you get passed in. Positional arguments get passed first and "unsplatted" (not combined into an array), the `Hash` containing keyword arguments comes after:
 
 ```ruby
 class HighlyConfigurableGreetingJob < ActiveJob::Base
@@ -112,7 +112,7 @@ To enqueue the job:
 HighlyConfigurableGreetingJob.perform_later(_subject_line = "Greetings everybody!", sender_name: "Jane", sender_email: "jane@host.example")
 ```
 
-Note that you cannot use `ruby2_keywords` at present.
+Note that you cannot use `ruby2_keywords` at present, and the keyword arguments syntax is not supported in `each_iteration` / `build_enumerator`.
 
 ### Returning (yielding) from enumerators
 

--- a/guides/argument-semantics.md
+++ b/guides/argument-semantics.md
@@ -97,7 +97,7 @@ class HighlyConfigurableGreetingJob < ActiveJob::Base
     # ...
   end
 
-  def each_iteration(subject_line, kwargs)
+  def each_iteration(object_yielded_from_enumerator, subject_line, kwargs)
     name = kwargs.fetch(:sender_name)
     email = kwargs.fetch(:sender_email)
     # ...
@@ -112,3 +112,16 @@ HighlyConfigurableGreetingJob.perform_later(_subject_line = "Greetings everybody
 ```
 
 Note that you cannot use `ruby2_keywords` at present.
+
+### Returning (yielding) from enumerators
+
+When defining a custom enumerator (see the [custom enumerator guide](custom-enumerator.md)) you need to yield two positional arguments from it: the object that will be value for the current iteration (like a single ActiveModel instance, a single number...) and value you want to be persisted as the `cursor` value should `job-iteration` decide to interrupt you. That new `cursor` value does not get passed to `each_iteration`:
+
+```ruby
+Enumerator.new do |yielder|
+  # In this case `cursor` is an Integer
+  cursor.upto(99999) do |offset|
+    yielder.yield(fetch_record_at(offset), offset)
+  end
+end
+```

--- a/guides/argument-semantics.md
+++ b/guides/argument-semantics.md
@@ -22,6 +22,7 @@ class ArglessJob < ActiveJob::Base
     # ...
   end
 end
+```
 
 To enqueue the job:
 

--- a/guides/argument-semantics.md
+++ b/guides/argument-semantics.md
@@ -116,7 +116,7 @@ Note that you cannot use `ruby2_keywords` at present, and the keyword arguments 
 
 ### Returning (yielding) from enumerators
 
-When defining a custom enumerator (see the [custom enumerator guide](custom-enumerator.md)) you need to yield two positional arguments from it: the object that will be value for the current iteration (like a single ActiveModel instance, a single number...) and value you want to be persisted as the `cursor` value should `job-iteration` decide to interrupt you. That new `cursor` value does not get passed to `each_iteration`:
+When defining a custom enumerator (see the [custom enumerator guide](custom-enumerator.md)) you need to yield two positional arguments from it: the object that will be the value for the current iteration (like a single ActiveModel instance, a single number...) and the value you want to be persisted as the `cursor` value should `job-iteration` decide to interrupt you after this iteration. Calling the enumerator with that cursor should return the next object after the one returned in this iteration. That new `cursor` value does not get passed to `each_iteration`:
 
 ```ruby
 Enumerator.new do |yielder|

--- a/guides/argument-semantics.md
+++ b/guides/argument-semantics.md
@@ -4,7 +4,7 @@ The call sequence is usually 3 methods:
 
 `perform -> build_enumerator -> each_iteration|each_batch`
 
-In that sense `job-iteration` works more like a framework (it calls your code) than like library (that you would call). When using jobs with parameters, the following rules of thumb are good to keep in mind.
+In that sense `job-iteration` works like a framework (it calls your code) rather than like a library (that you call). When using jobs with parameters, the following rules of thumb are good to keep in mind.
 
 ### Jobs without arguments
 


### PR DESCRIPTION
It is not really clear from the documentation how arguments to `perform` are supposed to propagate through the call stack, and if one needs to blind-explore it leads to some rather surprising results. Maybe documenting it could help?..