### PR TITLE
Support relations with a composite primary key

### DIFF
--- a/lib/job-iteration/active_record_cursor.rb
+++ b/lib/job-iteration/active_record_cursor.rb
@@ -19,8 +19,11 @@ module JobIteration
     end
 
     def initialize(relation, columns = nil, position = nil)
-      columns ||= "#{relation.table_name}.#{relation.primary_key}"
-      @columns = Array.wrap(columns)
+      @columns = if columns
+        Array(columns)
+      else
+        Array(relation.primary_key).map { |pk| "#{relation.table_name}.#{pk}" }
+      end
       self.position = Array.wrap(position)
       raise ArgumentError, "Must specify at least one column" if columns.empty?
       if relation.joins_values.present? && !@columns.all? { |column| column.to_s.include?(".") }

--- a/lib/job-iteration/active_record_enumerator.rb
+++ b/lib/job-iteration/active_record_enumerator.rb
@@ -10,7 +10,11 @@ module JobIteration
     def initialize(relation, columns: nil, batch_size: 100, cursor: nil)
       @relation = relation
       @batch_size = batch_size
-      @columns = Array(columns || "#{relation.table_name}.#{relation.primary_key}")
+      @columns = if columns
+        Array(columns)
+      else
+        Array(relation.primary_key).map { |pk| "#{relation.table_name}.#{pk}" }
+      end
       @cursor = cursor
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,6 +44,10 @@ ActiveJob::Base.queue_adapter = :iteration_test
 class Product < ActiveRecord::Base
 end
 
+class TravelRoute < ActiveRecord::Base
+  self.primary_key = [:origin, :destination]
+end
+
 host = ENV["USING_DEV"] == "1" ? "job-iteration.railgun" : "localhost"
 
 connection_config = {
@@ -68,9 +72,14 @@ Sidekiq.configure_client do |config|
   config.redis = { host: host }
 end
 
-ActiveRecord::Base.connection.create_table(Product.table_name, force: true) do |t|
+ActiveRecord::Base.connection.create_table(:products, force: true) do |t|
   t.string(:name)
   t.timestamps
+end
+
+ActiveRecord::Base.connection.create_table(:travel_routes, force: true, primary_key: [:origin, :destination]) do |t|
+  t.string(:destination)
+  t.string(:origin)
 end
 
 module LoggingHelpers
@@ -124,6 +133,7 @@ class IterationUnitTest < ActiveSupport::TestCase
   end
 
   def truncate_fixtures
+    ActiveRecord::Base.connection.truncate(TravelRoute.table_name)
     ActiveRecord::Base.connection.truncate(Product.table_name)
   end
 end

--- a/test/unit/active_record_enumerator_test.rb
+++ b/test/unit/active_record_enumerator_test.rb
@@ -105,6 +105,19 @@ module JobIteration
       assert_equal(10, enum.size)
     end
 
+    test "enumerator for a relation with a composite primary key" do
+      TravelRoute.create!(origin: "A", destination: "B")
+      TravelRoute.create!(origin: "A", destination: "C")
+      TravelRoute.create!(origin: "B", destination: "A")
+
+      enum = build_enumerator(relation: TravelRoute.all, batch_size: 2)
+
+      cursors = []
+      enum.records.each { |_record, cursor| cursors << cursor }
+
+      assert_equal([["A", "B"], ["A", "C"], ["B", "A"]], cursors)
+    end if ActiveRecord.version >= Gem::Version.new("7.1.0.alpha")
+
     private
 
     def build_enumerator(relation: Product.all, batch_size: 2, columns: nil, cursor: nil)


### PR DESCRIPTION
Both `ActiveRecordCursor` and `ActiveRecordEnumerator` already support `columns` argument being an array

In order to support iterations over models with a composite primary key the only thing that is required is to be able to build the default cursor columns based on the composite `primary_key` 

This PR adds support for models with a CPK by always treating `relation.primary_key` as an array. 

This is a non-breaking change since `columns` used to wrapped to `[:id]` anyway. However the test is only going to run on rails-edge run as officially Rails doesn't support composite primary keys yet and having a model like `TravelRoute` is only possible on the edge version of Rails