### PR TITLE
Yield updated instead of initial nested cursor to persist

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -189,7 +189,7 @@ module JobIteration
         # Deferred until 2.0.0
         # assert_valid_cursor!(cursor_from_enumerator)
 
-        tags = instrumentation_tags.merge(cursor_position: cursor_from_enumerator.dup)
+        tags = instrumentation_tags.merge(cursor_position: cursor_from_enumerator)
         ActiveSupport::Notifications.instrument("each_iteration.iteration", tags) do
           found_record = true
           each_iteration(object_from_enumerator, *arguments)

--- a/lib/job-iteration/nested_enumerator.rb
+++ b/lib/job-iteration/nested_enumerator.rb
@@ -30,7 +30,9 @@ module JobIteration
       enumerator.each do |object_from_enumerator, cursor_from_enumerator|
         if index == @cursors.size - 1
           # we've reached the innermost enumerator, yield for `iterate_with_enumerator`
-          yield object_from_enumerator, @cursors
+          updated_cursor = @cursors.dup
+          updated_cursor[index] = cursor_from_enumerator
+          yield object_from_enumerator, updated_cursor
         else
           # we need to go deeper
           next_index = index + 1
@@ -38,8 +40,8 @@ module JobIteration
           # reset cursor at the index of the nested enumerator that just finished, so we don't skip items when that
           # index is reused in the next nested iteration
           @cursors[next_index] = nil
+          @cursors[index] = cursor_from_enumerator
         end
-        @cursors[index] = cursor_from_enumerator
       end
     end
   end

--- a/test/unit/iteration_test.rb
+++ b/test/unit/iteration_test.rb
@@ -469,18 +469,18 @@ class JobIterationTest < IterationUnitTest
     end
 
     expected = [
-      { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [nil, nil] },
       { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [nil, 0] },
       { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [nil, 1] },
       { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [nil, 2] },
-      { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [0, nil] },
+      { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [nil, 3] },
       { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [0, 0] },
       { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [0, 1] },
       { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [0, 2] },
-      { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [1, nil] },
+      { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [0, 3] },
       { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [1, 0] },
       { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [1, 1] },
       { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [1, 2] },
+      { job_class: "JobIterationTest::JobWithNestedEnumerator", cursor_position: [1, 3] },
     ]
     assert_equal(expected, events)
   end

--- a/test/unit/nested_enumerator_test.rb
+++ b/test/unit/nested_enumerator_test.rb
@@ -29,7 +29,7 @@ module JobIteration
 
       products = Product.includes(:comments).order(:id).take(3)
       comments = products.flat_map { |product| product.comments.sort_by(&:id) }
-      cursors = [[nil, nil], [1, nil], [1, 2], [2, nil], [2, 4], [2, 5]]
+      cursors = [[nil, 1], [1, 2], [1, 3], [2, 4], [2, 5], [2, 6]]
 
       enum.each_with_index do |(comment, cursor), index|
         expected_comment = comments[index]
@@ -57,7 +57,7 @@ module JobIteration
     test "works with single level nesting" do
       enum = build_enumerator(inner: nil)
       products = Product.order(:id).to_a
-      cursors = [nil] + (1..9).to_a
+      cursors = (1..10).to_a
 
       enum.each_with_index do |(product, cursor), index|
         assert_equal(products[index], product)


### PR DESCRIPTION
Otherwise we reprocess the last successfully processed object again when resuming. In a pathologic case, if a nested job is interrupted every time after a single `each_iteration` completes we'd never progress: the cursor would stay at `[nil, nil]`.

I spelled it out in https://github.com/Shopify/job-iteration/pull/364 😅 but I originally worked on this months before and only realized it now.

Follow-up to https://github.com/Shopify/job-iteration/pull/310