### PR TITLE
Ensure type-safe serialization/deserialization of total time

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -112,7 +112,7 @@ module JobIteration
       super.merge(
         "cursor_position" => cursor_position,
         "times_interrupted" => times_interrupted,
-        "total_time" => total_time,
+        "total_time" => total_time.to_f,
       )
     end
 
@@ -120,7 +120,7 @@ module JobIteration
       super
       self.cursor_position = job_data["cursor_position"]
       self.times_interrupted = job_data["times_interrupted"] || 0
-      self.total_time = job_data["total_time"] || 0
+      self.total_time = job_data["total_time"].to_f || 0.0
     end
 
     def perform(*params) # @private


### PR DESCRIPTION
Under unknown circumstances, the extra `total_time` argument passed to instances of jobs is serialized/deserialized as a string instead of a float. That causes a `TypeError` due to an impossible type conversion.

Now the `total_time` argument is coerced to a float number prior its serialization and deserialization, respectively.

Fixes #396.