### PR TITLE
Return `nil` from `Iteration#perform`

### DIFF
--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -125,6 +125,8 @@ module JobIteration
 
     def perform(*params) # @private
       interruptible_perform(*params)
+
+      nil
     end
 
     def retry_job(*, **)

--- a/test/unit/iteration_test.rb
+++ b/test/unit/iteration_test.rb
@@ -485,6 +485,11 @@ class JobIterationTest < IterationUnitTest
     assert_equal(expected, events)
   end
 
+  def test_perform_returns_nil
+    # i.e. perform is "void", and nobody should depend on the return value
+    assert_nil(JobWithRightMethods.perform_now({}))
+  end
+
   private
 
   # Allows building job classes that read max_job_runtime during the test,


### PR DESCRIPTION
`perform` should be treated as `void`, with consumers not coupling to its return value.

Explicitly returning `nil` ensures the return value does not change if we happen to change the implementation.