### PR TITLE
Extract separate CI linting job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       redis:
         image: redis
         ports:
-        - 6379:6379
+          - 6379:6379
     strategy:
       matrix:
         ruby: ["2.7", "3.0", "3.1", "3.2"]
@@ -22,7 +22,7 @@ jobs:
           - ruby: "3.2"
             gemfile: rails_6_0
           - ruby: "3.2"
-            gemfile: rails_6_1        
+            gemfile: rails_6_1
 
         include:
           - ruby: head
@@ -30,23 +30,23 @@ jobs:
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
-    - name: Check out code
-      uses: actions/checkout@v3
-    - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true
-    - name: Start MySQL and create DB
-      run: |
-        sudo systemctl start mysql.service
-        mysql -uroot -h localhost -proot -e "CREATE DATABASE job_iteration_test;"
-    - name: Rubocop
-      run: bundle exec rubocop
-    - name: Ruby tests
-      run: bundle exec rake test
-      env:
-        REDIS_HOST: localhost
-        REDIS_PORT: ${{ job.services.redis.ports[6379] }}
-    - name: Documentation correctly written
-      run: bundle exec yardoc --no-output --no-save --no-stats --fail-on-warning
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Start MySQL and create DB
+        run: |
+          sudo systemctl start mysql.service
+          mysql -uroot -h localhost -proot -e "CREATE DATABASE job_iteration_test;"
+      - name: Rubocop
+        run: bundle exec rubocop
+      - name: Ruby tests
+        run: bundle exec rake test
+        env:
+          REDIS_HOST: localhost
+          REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+      - name: Documentation correctly written
+        run: bundle exec yardoc --no-output --no-save --no-stats --fail-on-warning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,12 +41,24 @@ jobs:
         run: |
           sudo systemctl start mysql.service
           mysql -uroot -h localhost -proot -e "CREATE DATABASE job_iteration_test;"
-      - name: Rubocop
-        run: bundle exec rubocop
       - name: Ruby tests
         run: bundle exec rake test
         env:
           REDIS_HOST: localhost
           REDIS_PORT: ${{ job.services.redis.ports[6379] }}
+
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+      - name: Rubocop
+        run: bundle exec rubocop
       - name: Documentation correctly written
         run: bundle exec yardoc --no-output --no-save --no-stats --fail-on-warning

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_gem:
   rubocop-shopify: rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.7.6
+  TargetRubyVersion: 2.7
   Exclude:
     - "vendor/bundle/**/*"
 Lint/SuppressedException:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ inherit_gem:
 AllCops:
   TargetRubyVersion: 2.7.6
   Exclude:
-    - 'vendor/bundle/**/*'
+    - "vendor/bundle/**/*"
 Lint/SuppressedException:
   Exclude:
     - lib/job-iteration.rb
@@ -16,5 +16,5 @@ Naming/FileName:
     - lib/job-iteration.rb
 Style/MethodCallWithArgsParentheses:
   Exclude:
-    - 'gemfiles/*'
+    - "gemfiles/*"
     - Gemfile

--- a/test/rubocop_config_test.rb
+++ b/test/rubocop_config_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "yaml"
+
+module JobIteration
+  class RubocopConfigTest < ActiveSupport::TestCase
+    test "TargetRubyVersion in .rubocop.yml matches oldest Ruby in CI matrix" do
+      assert_equal(
+        oldest_ruby_in_matrix,
+        target_ruby_version,
+        "TargetRubyVersion in .rubocop.yml does not match oldest Ruby in CI matrix",
+      )
+    end
+
+    test "Linting runs on the newest Ruby in CI matrix" do
+      assert_equal(
+        newest_ruby_in_matrix,
+        ruby_version_for_linting,
+        "Linting does not run on the newest Ruby in CI matrix",
+      )
+    end
+
+    test "TargetRubyVersion in .rubocop.yml matches required Ruby version in gemspec" do
+      assert_equal(
+        required_ruby_version,
+        target_ruby_version,
+        "TargetRubyVersion in .rubocop.yml does not match required Ruby version in gemspec",
+      )
+    end
+
+    private
+
+    def oldest_ruby_in_matrix
+      ruby_versions_in_matrix.min
+    end
+
+    def newest_ruby_in_matrix
+      ruby_versions_in_matrix.max
+    end
+
+    def ruby_versions_in_matrix
+      YAML
+        .load_file(".github/workflows/ci.yml")
+        .dig("jobs", "build", "strategy", "matrix", "ruby")
+        .tap { |ruby_versions| refute_nil(ruby_versions, "Ruby versions not found in CI matrix") }
+        .map { |ruby_version| Gem::Version.new(ruby_version) }
+    end
+
+    def ruby_version_for_linting
+      YAML
+        .load_file(".github/workflows/ci.yml")
+        .dig("jobs", "lint", "steps")
+        .tap { |steps| refute_nil(steps, "Steps not found in linting CI config") }
+        .find { |step| step.fetch("uses", "") =~ %r{^ruby/setup-ruby} }
+        .tap { |step| refute_nil(step, "Ruby setup step not found in linting CI config") }
+        .then { |step| step.dig("with", "ruby-version") }
+        .tap { |ruby_version| refute_nil(ruby_version, "Ruby version not found in linting CI config") }
+        .then { |ruby_version| Gem::Version.new(ruby_version) }
+    end
+
+    def target_ruby_version
+      YAML
+        .load_file(".rubocop.yml")
+        .dig("AllCops", "TargetRubyVersion")
+        .tap { |ruby_version| refute_nil(ruby_version, "TargetRubyVersion not found in .rubocop.yml") }
+        .then { |ruby_version| Gem::Version.new(ruby_version) }
+    end
+
+    def required_ruby_version
+      Gem
+        .loaded_specs
+        .fetch("job-iteration")
+        .required_ruby_version
+        .to_s[/(?<=>= )\d+\.\d+/]
+        .then { |ruby_version| Gem::Version.new(ruby_version) }
+    end
+  end
+end


### PR DESCRIPTION
Because Rubocop allows us to specify a `TargetRubyVersion`, we don't need to run the linting step across every Ruby version – we can simply run it with the latest, while setting the `TargetRubyVersion` to the oldest.[^1]

[^1]: Tests are added to ensure these values are kept in sync.