### PR TITLE
Support AR Enumerators for models with composite primary keys using :id

### DIFF
--- a/lib/job-iteration/active_record_cursor.rb
+++ b/lib/job-iteration/active_record_cursor.rb
@@ -55,7 +55,12 @@ module JobIteration
     def update_from_record(record)
       self.position = @columns.map do |column|
         method = column.to_s.split(".").last
-        record.send(method.to_sym)
+
+        if ActiveRecord.version >= Gem::Version.new("7.1.0.alpha") && method == "id"
+          record.id_value
+        else
+          record.send(method.to_sym)
+        end
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -53,8 +53,8 @@ class TravelRoute < ActiveRecord::Base
   self.primary_key = [:origin, :destination]
 end
 
-class TravelRoute < ActiveRecord::Base
-  self.primary_key = [:origin, :destination]
+class Order < ActiveRecord::Base
+  self.primary_key = [:shop_id, :id]
 end
 
 host = ENV["USING_DEV"] == "1" ? "job-iteration.railgun" : "localhost"
@@ -95,6 +95,11 @@ ActiveRecord::Schema.define do
   create_table(:travel_routes, force: true, primary_key: [:origin, :destination]) do |t|
     t.string(:destination)
     t.string(:origin)
+  end
+
+  create_table(:orders, force: true) do |t|
+    t.integer(:shop_id)
+    t.string(:name)
   end
 end
 


### PR DESCRIPTION
We need to use `#id_value` instead of `#id` for models with composite primary keys when accessing the record value, because `#id` gives us back the primary key value when we want the `:id` column value.