### PR TITLE
Use min max job runtime between class & global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 ### Main (unreleased)
 
+### Changes
+
+- [437](https://github.com/Shopify/job-iteration/pull/437) - Use minimum between per-class `job_iteration_max_job_runtime` and `JobIteration.max_job_runtime`, instead of enforcing only setting decreasing values.
+  Because it is possible to change the global or parent values after setting the value on a class, it is not possible to truly enforce the decreasing value constraint. Instead, we now use the minimum between the global value and per-class value. This is considered a non-breaking change, as it should not break any **existing** code, it only removes the constraint on new classes.
+
 ### Bug fixes
 
+- [437](https://github.com/Shopify/job-iteration/pull/437) - Defer reading `JobIteration.max_job_runtime` until runtime, instead of closing around the value at the time of job definition.
 - [431](https://github.com/Shopify/job-iteration/pull/431) - Use `#id_value` instead of `send(:id)`
 when generating position for cursor based on `:id` column (Rails 7.1 and above, where composite
 primary models are now supported). This ensures we grab the value of the id column, rather than a

--- a/lib/job-iteration.rb
+++ b/lib/job-iteration.rb
@@ -29,13 +29,21 @@ module JobIteration
   # This setting will make it to always interrupt a job after it's been iterating for 5 minutes.
   # Defaults to nil which means that jobs will not be interrupted except on termination signal.
   #
-  # This setting can be further reduced (but not increased) by using the inheritable per-class
-  # job_iteration_max_job_runtime setting.
+  # This setting can be overriden by using the inheritable per-class job_iteration_max_job_runtime setting. At runtime,
+  # the lower of the two will be used.
   # @example
   #
   #   class MyJob < ActiveJob::Base
   #     include JobIteration::Iteration
   #     self.job_iteration_max_job_runtime = 1.minute
+  #     # ...
+  #
+  # Note that if a sub-class overrides its parent's setting, only the global and sub-class setting will be considered,
+  # not the parent's.
+  # @example
+  #
+  #   class ChildJob < MyJob
+  #     self.job_iteration_max_job_runtime = 3.minutes # MyJob's 1.minute will be discarded.
   #     # ...
   attr_accessor :max_job_runtime
 


### PR DESCRIPTION
The existing approach set `JobIteration.max_job_runtime` as the default value of the `job_iteration_max_job_runtime` `class_attribute`. However, this approach would close around the value at the time the `Iteration` module was included in the host `class`.

This means that if a job class is defined before the host application sets `max_job_runtime`, the setting will not be honoured. For example, if using the `maintenance_tasks` gem, which defines a `TaskJob`, the default would be read when the gem is loaded, prior to initializers running, which is where the host application typically sets the global `max_job_runtime`.

This commit changes the implementation in the following ways:

- We no longer restrict the ability to increase the maximum in child classes. There were ways to get around the restriction, and there may be legitimate scenarios in which an application needs to allow an job to exceed its parent class' maximum job runtime, so we can simplify the implementation by removing the constraint.
- We now take the minimum between the class attribute and the global maximum, which works around the default race, while still ensuring the application can enforce a maximum across all jobs, for stability.

This is an alternative implementation to #436, with the goal of being simpler.

---

Closes #436 