### PR TITLE
Refactor gemfiles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,17 @@ gemspec
 gem "sidekiq"
 gem "resque"
 
+if defined?(@rails_gems_requirements) && @rails_gems_requirements
+  # We avoid the `gem "..."` syntax here so Dependabot doesn't try to update these gems.
+  [
+    "activejob",
+    "activerecord",
+  ].each { |name| gem name, @rails_gems_requirements }
+else
+  # gem "activejob" # Set in gemspec
+  gem "activerecord"
+end
+
 gem "mysql2", github: "brianmario/mysql2"
 gem "globalid"
 gem "i18n"

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-eval_gemfile "../Gemfile"
+@rails_gems_requirements = "~> 5.2.0"
 
-gem "activejob", "~> 5.2.0"
-gem "activerecord", "~> 5.2.0"
+eval_gemfile "../Gemfile"

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-eval_gemfile "../Gemfile"
+@rails_gems_requirements = "~> 6.0.0"
 
-gem "activejob", "~> 6.0.0"
-gem "activerecord", "~> 6.0.0"
+eval_gemfile "../Gemfile"

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+@rails_gems_requirements = "~> 6.1.0"
+
 eval_gemfile "../Gemfile"
 
 if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("3.1")
@@ -7,6 +9,3 @@ if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new("3.1")
   gem "net-pop", require: false
   gem "net-smtp", require: false
 end
-
-gem "activejob", "~> 6.1.0"
-gem "activerecord", "~> 6.1.0"

--- a/gemfiles/rails_7_0.gemfile
+++ b/gemfiles/rails_7_0.gemfile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-eval_gemfile "../Gemfile"
+@rails_gems_requirements = "~> 7.0.0"
 
-gem "activejob", "~> 7.0.0"
-gem "activerecord", "~> 7.0.0"
+eval_gemfile "../Gemfile"

--- a/gemfiles/rails_edge.gemfile
+++ b/gemfiles/rails_edge.gemfile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-eval_gemfile "../Gemfile"
+@rails_gems_requirements = { github: "rails/rails", branch: "main" }
 
-gem "activejob", github: "rails/rails", branch: "main"
-gem "activerecord", github: "rails/rails", branch: "main"
+eval_gemfile "../Gemfile"

--- a/job-iteration.gemspec
+++ b/job-iteration.gemspec
@@ -26,6 +26,5 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/Shopify/job-iteration/blob/main/CHANGELOG.md"
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  spec.add_development_dependency("activerecord")
   spec.add_dependency("activejob", ">= 5.2")
 end


### PR DESCRIPTION
We have several gemfiles in which we have specific version requirements for `activejob` and `activerecord`, for use in our CI matrix.

The current approach breaks on Ruby HEAD because it is detected as specifying multiple versions/sources for those gems. Instead, this refactors them to use an instance variable approach, similar to that used in Shopify/maintenance_tasks.