### PR TITLE
Add `JobIteration::Deprecation`

### DIFF
--- a/lib/job-iteration.rb
+++ b/lib/job-iteration.rb
@@ -5,6 +5,7 @@ require_relative "./job-iteration/version"
 require_relative "./job-iteration/enumerator_builder"
 require_relative "./job-iteration/iteration"
 require_relative "./job-iteration/log_subscriber"
+require_relative "./job-iteration/railtie"
 
 module JobIteration
   IntegrationLoadError = Class.new(StandardError)

--- a/lib/job-iteration.rb
+++ b/lib/job-iteration.rb
@@ -12,6 +12,8 @@ module JobIteration
 
   INTEGRATIONS = [:resque, :sidekiq]
 
+  Deprecation = ActiveSupport::Deprecation.new("2.0", "JobIteration")
+
   extend self
 
   attr_writer :logger

--- a/lib/job-iteration/railtie.rb
+++ b/lib/job-iteration/railtie.rb
@@ -4,5 +4,9 @@ return unless defined?(Rails::Railtie)
 
 module JobIteration
   class Railtie < Rails::Railtie
+    initializer "job_iteration.register_deprecator" do |app|
+      # app.deprecators was added in Rails 7.1
+      app.deprecators[:job_iteration] = JobIteration::Deprecation if app.respond_to?(:deprecators)
+    end
   end
 end

--- a/lib/job-iteration/railtie.rb
+++ b/lib/job-iteration/railtie.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+return unless defined?(Rails::Railtie)
+
+module JobIteration
+  class Railtie < Rails::Railtie
+  end
+end


### PR DESCRIPTION
This adds a `Deprecation` object using `ActiveSupport::Deprecation`, allowing us to log fancy deprecation warnings.

It has been extracted from #81, as it will also be relevant in other PRs.

I believe the missing piece #81 needed to properly work with `DeprecationToolkit` was that we not only needed to configure it to `attach_to` our deprecations, but we also needed to add our `Deprecation` to the host application's `deprecators`, so `DeprecationToolkit` will add the `:notify` behavior to it, so it has notifications to subscribe to.[^1] The simplest way to do this is for us to  use a `Railtie` to register an initializer which does it.

[^1]: I feel like there's some documentation that could be improved, either in Rails or in `DeprecationToolkit` to capture this.