### PR TITLE
Add while  enumerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [437](https://github.com/Shopify/job-iteration/pull/437) - Use minimum between per-class `job_iteration_max_job_runtime` and `JobIteration.max_job_runtime`, instead of enforcing only setting decreasing values.
   Because it is possible to change the global or parent values after setting the value on a class, it is not possible to truly enforce the decreasing value constraint. Instead, we now use the minimum between the global value and per-class value. This is considered a non-breaking change, as it should not break any **existing** code, it only removes the constraint on new classes.
+- [446](https://github.com/Shopify/job-iteration/pull/446) - Support while loop enumerator
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,25 @@ class NestedIterationJob < ApplicationJob
 end
 ```
 
+
+```ruby
+class DeleteXyzJob < ApplicationJob
+  include JobIteration::Iteration
+
+  def build_enumerator(params)
+    enumerator_builder.while { query_model_xyz(params).exists? }
+  end
+
+  def each_iteration(count, params)
+    query_model_xyz(params).limit(1000).delete_all
+  end
+
+  def query_model_xyz(params)
+    Xyz.where(owner_id: params[:owner_id])
+  end
+end
+```
+
 Iteration hooks into Sidekiq and Resque out of the box to support graceful interruption. No extra configuration is required.
 
 ## Guides

--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -181,6 +181,29 @@ module JobIteration
       NestedEnumerator.new(enums, cursor: cursor).each
     end
 
+    # Builds Enumerator for while loop iteration.
+    #
+    # @yield Condition to be evaluated before each iteration, the iteration is allowed if a true value is returned.
+    #
+    # @example
+    #   def build_enumerator(params)
+    #     enumerator_builder.while { query_model_xyz(params).exists? }
+    #   end
+    #
+    #   def each_iteration(_, params)
+    #     query_model_xyz(params).limit(1000).delete_all
+    #   end
+    #
+    #   def query_model_xyz(params)
+    #     Xyz.where(owner_id: params[:owner_id])
+    #   end
+    #
+    def build_while_enumerator(&condition)
+      Enumerator.new do |yielder|
+        yielder << nil while condition.call
+      end
+    end
+
     alias_method :once, :build_once_enumerator
     alias_method :times, :build_times_enumerator
     alias_method :array, :build_array_enumerator
@@ -190,6 +213,7 @@ module JobIteration
     alias_method :throttle, :build_throttle_enumerator
     alias_method :csv, :build_csv_enumerator
     alias_method :nested, :build_nested_enumerator
+    alias_method :while, :build_while_enumerator
 
     private
 

--- a/test/unit/enumerator_builder_test.rb
+++ b/test/unit/enumerator_builder_test.rb
@@ -74,6 +74,15 @@ module JobIteration
       )
     end
 
+    test_builder_method(:build_while_enumerator) do
+      count = 0
+      enum = enumerator_builder(wraps: 0).build_while_enumerator do
+        count < 3 ? (count += 1) : false
+      end
+
+      assert_equal [nil, nil, nil], enum.to_a
+    end
+
     # checks that all the non-alias methods were tested
     raise "methods not tested: #{methods.inspect}" unless methods.empty?
 


### PR DESCRIPTION
Follow up for: 
- https://github.com/Shopify/shopify/pull/470718

The original implementation of that PR was querying some records in batches using the `enumerator_builder.active_record_on_batches`, collecting the ids for iteration and then deleting the records. The problem is that we don't really need to query and load all the records into memory just to grab the ids to deleted them. We can just run a super fast query like `.exists?`, and then run the delete command in batches while there are records.

This PR adds a new `enumerator_builder.while`, where any code block can be based and the iteration will be allowed when the returned value is true.