### PR TITLE
Prepare for isogun removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .ruby-version
 .rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
 gemfiles/*.lock
+dump.rdb

--- a/dev.yml
+++ b/dev.yml
@@ -3,17 +3,16 @@
 name: job-iteration
 
 up:
-  - homebrew:
-    - mysql-client:
-        or:        [mysql@5.7]
-  - ruby:
-      version: 2.7.6
-  - isogun
+  - packages:
+      - mysql_client
+  - ruby: 2.7.6
   - bundler
+  - mysql
+  - redis
   - custom:
       name: Create Job Iteration database
-      meet: mysql -uroot -h job-iteration.railgun -e "CREATE DATABASE job_iteration_test"
-      met?: mysql -uroot -h job-iteration.railgun job_iteration_test -e "SELECT 1" &> /dev/null
+      meet: mysql -uroot -h $MYSQL_HOST -P $MYSQL_PORT -e "CREATE DATABASE job_iteration_test"
+      met?: mysql -uroot -h $MYSQL_HOST -P $MYSQL_PORT job_iteration_test -e "SELECT 1" &> /dev/null
 
 commands:
   test:

--- a/isogun.yml
+++ b/isogun.yml
@@ -1,4 +1,3 @@
-# https://development.shopify.io/tools/dev/railgun/Railgun-Config
 name: job-iteration
 
 vm:

--- a/test/support/resque/Rakefile
+++ b/test/support/resque/Rakefile
@@ -11,10 +11,8 @@ require "i18n"
 
 require_relative "../jobs"
 
-redis_host = ENV.fetch("REDIS_HOST") { "localhost" }
-redis_port = ENV.fetch("REDIS_PORT") { 6379 }
-
-Resque.redis = "#{redis_host}:#{redis_port}"
+redis_url = ENV.fetch("REDIS_URL") { "redis://localhost:6379/0" }
+Resque.redis = redis_url
 
 I18n.available_locales = [:en]
 ActiveJob::Base.queue_adapter = :resque

--- a/test/support/resque/Rakefile
+++ b/test/support/resque/Rakefile
@@ -11,13 +11,10 @@ require "i18n"
 
 require_relative "../jobs"
 
-redis_url = if ENV["USING_DEV"] == "1"
-  "job-iteration.railgun:6379"
-else
-  "localhost:6379"
-end
+redis_host = ENV.fetch("REDIS_HOST") { "localhost" }
+redis_port = ENV.fetch("REDIS_PORT") { 6379 }
 
-Resque.redis = redis_url
+Resque.redis = "#{redis_host}:#{redis_port}"
 
 I18n.available_locales = [:en]
 ActiveJob::Base.queue_adapter = :resque

--- a/test/support/sidekiq/init.rb
+++ b/test/support/sidekiq/init.rb
@@ -8,11 +8,10 @@ require "i18n"
 
 require_relative "../jobs"
 
-redis_host = ENV.fetch("REDIS_HOST") { "localhost" }
-redis_port = ENV.fetch("REDIS_PORT") { 6379 }
+redis_url = ENV.fetch("REDIS_URL") { "redis://localhost:6379/0" }
 
 Sidekiq.configure_server do |config|
-  config.redis = { host: redis_host, port: redis_port }
+  config.redis = { url: redis_url }
 end
 
 I18n.available_locales = [:en]

--- a/test/support/sidekiq/init.rb
+++ b/test/support/sidekiq/init.rb
@@ -8,14 +8,11 @@ require "i18n"
 
 require_relative "../jobs"
 
-redis_host = if ENV["USING_DEV"] == "1"
-  "job-iteration.railgun"
-else
-  "localhost"
-end
+redis_host = ENV.fetch("REDIS_HOST") { "localhost" }
+redis_port = ENV.fetch("REDIS_PORT") { 6379 }
 
 Sidekiq.configure_server do |config|
-  config.redis = { host: redis_host }
+  config.redis = { host: redis_host, port: redis_port }
 end
 
 I18n.available_locales = [:en]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -71,23 +71,17 @@ connection_config[:password] = "root" if ENV["CI"]
 
 ActiveRecord::Base.establish_connection(connection_config)
 
-redis_host = ENV.fetch("REDIS_HOST") { "localhost" }
-redis_port = ENV.fetch("REDIS_PORT") { 6379 }
+redis_url = ENV.fetch("REDIS_URL") { "redis://localhost:6379/0" }
 
 Redis.singleton_class.class_eval do
   attr_accessor :current
 end
 
-Redis.current = Redis.new(
-  host: redis_host,
-  port: redis_port,
-  timeout: 1.0,
-).tap(&:ping)
-
+Redis.current = Redis.new(url: redis_url, timeout: 1.0).tap(&:ping)
 Resque.redis = Redis.current
 
 Sidekiq.configure_client do |config|
-  config.redis = { host: redis_host, port: redis_port }
+  config.redis = { url: redis_url }
 end
 
 ActiveRecord::Schema.define do


### PR DESCRIPTION
The isogun VM is deprecated for local development. This PR makes changes that should work both with and without isogun, to prepare for its eventual demise.