### PR TITLE
Explicitly require csv for for Ruby head

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,7 @@ gem "mocha"
 gem "rubocop-shopify", require: false
 gem "yard"
 gem "rake"
+gem "csv" # required for Ruby 3.4+
 
 # for unit testing optional sorbet support
 gem "sorbet-runtime"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,6 +30,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.4.1)
+    csv (3.2.8)
     globalid (1.1.0)
       activesupport (>= 5.0)
     i18n (1.14.1)
@@ -109,6 +110,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord
+  csv
   globalid
   i18n
   job-iteration!

--- a/lib/job-iteration/csv_enumerator.rb
+++ b/lib/job-iteration/csv_enumerator.rb
@@ -20,7 +20,7 @@ module JobIteration
     #   csv = CSV.open('tmp/files', { converters: :integer, headers: true })
     #   JobIteration::CsvEnumerator.new(csv).rows(cursor: cursor)
     def initialize(csv)
-      unless csv.instance_of?(CSV)
+      unless defined?(CSV) && csv.instance_of?(CSV)
         raise ArgumentError, "CsvEnumerator.new takes CSV object"
       end
 


### PR DESCRIPTION
Some bundled gems are being removed from Ruby and need to be specified in the Gemfile with Ruby 3.4: https://bugs.ruby-lang.org/issues/20187

This PR adds the CSV gem to our Gemfile for use in testing.

I don't think we need to add it to the Gemspec? If users don't use the CSVEnumerator, they shouldn't need the gem, right? 