### PR TITLE
Use Arel instead of String for AR Enumerator conditionals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 when generating position for cursor based on `:id` column (Rails 7.1 and above, where composite
 primary models are now supported). This ensures we grab the value of the id column, rather than a
 potentially composite primary key value.
+- [456](https://github.com/Shopify/job-iteration/pull/431) - Use Arel to generate SQL that's type compatible for the
+  cursor pagination conditionals in ActiveRecord cursor. Previously, the cursor would coerce numeric ids to a string value 
+  (e.g.: `... AND id > '1'`)
 
 ## v1.4.1 (Sep 5, 2023)
 

--- a/lib/job-iteration/active_record_cursor.rb
+++ b/lib/job-iteration/active_record_cursor.rb
@@ -18,12 +18,8 @@ module JobIteration
       end
     end
 
-    def initialize(relation, columns = nil, position = nil)
-      @columns = if columns
-        Array(columns)
-      else
-        Array(relation.primary_key).map { |pk| "#{relation.table_name}.#{pk}" }
-      end
+    def initialize(relation, columns, position = nil)
+      @columns = columns
       self.position = Array.wrap(position)
       raise ArgumentError, "Must specify at least one column" if columns.empty?
       if relation.joins_values.present? && !@columns.all? { |column| column.to_s.include?(".") }
@@ -34,7 +30,7 @@ module JobIteration
         raise ConditionNotSupportedError
       end
 
-      @base_relation = relation.reorder(@columns.join(","))
+      @base_relation = relation.reorder(*@columns)
       @reached_end = false
     end
 
@@ -54,12 +50,10 @@ module JobIteration
 
     def update_from_record(record)
       self.position = @columns.map do |column|
-        method = column.to_s.split(".").last
-
-        if ActiveRecord.version >= Gem::Version.new("7.1.0.alpha") && method == "id"
+        if ActiveRecord.version >= Gem::Version.new("7.1.0.alpha") && column.name == "id"
           record.id_value
         else
-          record.send(method.to_sym)
+          record.send(column.name)
         end
       end
     end
@@ -89,14 +83,14 @@ module JobIteration
       i = @position.size - 1
       column = @columns[i]
       conditions = if @columns.size == @position.size
-        "#{column} > ?"
+        column.gt(@position[i])
       else
-        "#{column} >= ?"
+        column.gteq(@position[i])
       end
       while i > 0
         i -= 1
         column = @columns[i]
-        conditions = "#{column} > ? OR (#{column} = ? AND (#{conditions}))"
+        conditions = column.gt(@position[i]).or(column.eq(@position[i]).and(conditions))
       end
       ret = @position.reduce([conditions]) { |params, value| params << value << value }
       ret.pop

--- a/lib/job-iteration/active_record_enumerator.rb
+++ b/lib/job-iteration/active_record_enumerator.rb
@@ -11,13 +11,7 @@ module JobIteration
       @relation = relation
       @batch_size = batch_size
       @columns = if columns
-        Array(columns).map do |column|
-          if column.is_a?(Arel::Attributes::Attribute)
-            column
-          else
-            relation.arel_table[column.to_sym]
-          end
-        end
+        Array(columns).map { |col| relation.arel_table[col.to_sym] }
       else
         Array(relation.primary_key).map { |pk| relation.arel_table[pk.to_sym] }
       end

--- a/test/unit/active_record_enumerator_test.rb
+++ b/test/unit/active_record_enumerator_test.rb
@@ -4,6 +4,8 @@ require "test_helper"
 
 module JobIteration
   class ActiveRecordEnumeratorTest < IterationUnitTest
+    include ActiveRecordHelpers
+
     SQL_TIME_FORMAT = "%Y-%m-%d %H:%M:%S.%N"
     test "#records yields every record with their cursor position" do
       enum = build_enumerator.records
@@ -130,6 +132,13 @@ module JobIteration
         enum.records.each { |record, _cursor| order_names << record.name }
 
         assert_equal(["Red hat", "Blue jeans", "Yellow socks"], order_names)
+      end
+    end
+
+    test "enumerator paginates using integer conditionals for primary key when no columns are defined" do
+      enum = build_enumerator(relation: Product.all, batch_size: 1).records
+      assert_sql(/`products`\.`id` > 1/) do
+        enum.take(2)
       end
     end
 


### PR DESCRIPTION
# Problem statement

On our application we noticed some inconsistencies with the usage of Rails 7.1 and job-iteration.

For example:
```ruby
enumerator_builder.active_record_on_batches(Model.all, cursor: cursor)
```

when iterating would result in queries like:
```sql
 WHERE (reconciled_transaction_fees.id > '238427110') ORDER BY reconciled_transaction_fees.id LIMIT 3
 WHERE (reconciled_transaction_fees.id > '304256793') ORDER BY reconciled_transaction_fees.id LIMIT 3
 WHERE (reconciled_transaction_fees.id > '421883103') ORDER BY reconciled_transaction_fees.id LIMIT 3
```

While `reconciled_transaction_fees.id > '421883103'` is not wrong for adapters like MySQL and Postgres, it relies on behaviour from those DBMS to convert from strings to integer and still use the indices.

While working on a BigQuery adapter for ActiveRecord, we noticed that BigQuery will raise when comparing numeric columns with strings.

# Proposal

So instead of manipulating strings to build the paging conditional:
https://github.com/Shopify/job-iteration/blob/main/lib/job-iteration/active_record_batch_enumerator.rb#L97-L101

We propose using Rails Arel:
https://github.com/Shopify/job-iteration/blob/5d18040d0b12350089b03b4e57f908b84dbb5b57/lib/job-iteration/active_record_cursor.rb#L82-L86

which will emit queries without the quotes:
```sql
WHERE `reconciled_transaction_fees`.`id` > 238427110 ORDER BY `reconciled_transaction_fees`.`id` LIMIT 3
WHERE `reconciled_transaction_fees`.`id` > 304256793 ORDER BY `reconciled_transaction_fees`.`id` LIMIT 3
WHERE `reconciled_transaction_fees`.`id` > 421883103 ORDER BY `reconciled_transaction_fees`.`id` LIMIT 3
```

# What's in this PR?

These changes affect:
- enumerator_builder.active_record_on_records
- enumerator_builder.active_record_on_batches

The change affects only the `columns:` optional argument.
- `columns:` can still be passed as strings or symbols. Internally, the job-iteration code will convert the symbols to Arel attributes and manipulate them as Arel instead of strings.
~- (new!) `columns:` can also be passed as Arel attributes.~

# The Ugly

There are 2 main problems with the approach:
1) Arel is a private API subject to change. I tested this with Rails 7 (the job-iteration unit tests) and 7.1 (my app's unit tests). I'm relying on CI to test against other builds.

2) The new code **does not support** multi-column cursor when more than one table is used (`cursor: ["products.id", "comments.id"]`). While trying to add support to that, I created a test file and noticed that  job-iteration code had a bug for multi-column cursors on different tables. This PR does not resolve the bug (#457 )