### PR TITLE
Fix columns error when using join queries

### DIFF
--- a/lib/job-iteration/active_record_cursor.rb
+++ b/lib/job-iteration/active_record_cursor.rb
@@ -22,7 +22,7 @@ module JobIteration
       @columns = columns
       self.position = Array.wrap(position)
       raise ArgumentError, "Must specify at least one column" if columns.empty?
-      if relation.joins_values.present? && !@columns.all? { |column| column.to_s.include?(".") }
+      if relation.joins_values.present? && !@columns.all? { |column| column.is_a?(Arel::Attributes::Attribute) || column.to_s.include?(".") }
         raise ArgumentError, "You need to specify fully-qualified columns if you join a table"
       end
 


### PR DESCRIPTION
When using the ActiveRecordEnumerator, Update validation of columns in active record enumerator to allow for Arel and String values.

This fixes a an issue where using join queries kept running into the columns error and passing in columns with `.` values would cause errors when the query was executed.

Example
```ruby
# This would produce an error due to no "fully-qualified" columns
enumerator_builder.active_record_on_records(
  User.join(:memberships).where(memberships: { role: 'host' }),
  cursor: cursor,
  batch_size: 1
)

# If you add a columns field with symbols, you get the no fully-qualified columns error again
enumerator_builder.active_record_on_records(
  User.join(:memberships).where(memberships: { role: 'host' }),
  cursor: cursor,
  batch_size: 1,
  columns: [:id]
)

# If you attempted to add a string value with a fully-qualified column, you get a sql error when executing the query
enumerator_builder.active_record_on_records(
  User.join(:memberships).where(memberships: { role: 'host' }),
  cursor: cursor,
  batch_size: 1
  cursor: ['users.id']
)
# Produces a double table name in the sql query
`ORDER BY "users"."users.id"`
```

The change this PR is to only raise the error if the columns are not all `Arel::Attributes::Attribute` or string with no `.` in it. When you call `to_s` on a `Arel::Attributes::Attribute` it becomes fully qualified.

I believe this condition just missed getting updated with the move to convert all columns to Arel attributes for the `ActiveRecordEnumerator`, in this PR https://github.com/Shopify/job-iteration/pull/456 from earlier this year.