### PR TITLE
Allow instance of ActiveRecord::Base in array enumerators

### DIFF
--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -55,9 +55,6 @@ module JobIteration
       unless enumerable.is_a?(Array)
         raise ArgumentError, "enumerable must be an Array"
       end
-      if enumerable.any? { |i| defined?(ActiveRecord) && i.is_a?(ActiveRecord::Base) }
-        raise ArgumentError, "array cannot contain ActiveRecord objects"
-      end
 
       drop =
         if cursor.nil?


### PR DESCRIPTION
I'm removing the check on ActiveRecord::Base instance in the array enumerator to allow single AR records. There is a check already on Array so no ActiveRelation::Relation are given as the base enumerator. From a discussion with @kirs, this check is too defensive in the case that someone accidently tries to use the array enumerator on AR relation.