### PR TITLE
Revert "Use Arel instead of String for AR Enumerator conditionals"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### Main (unreleased)
 Nil
 
+## v1.5.1 (May 29,2024)
+- [483](https://github.com/Shopify/job-iteration/pull/483) Reverts [#456 Use Arel instead of String for AR Enumerator conditionals](https://github.com/Shopify/job-iteration/pull/456)
+
 ## v1.5.0 (May 29, 2024)
 ### Changes
 
@@ -17,6 +20,9 @@ Nil
 when generating position for cursor based on `:id` column (Rails 7.1 and above, where composite
 primary models are now supported). This ensures we grab the value of the id column, rather than a
 potentially composite primary key value.
+- [456](https://github.com/Shopify/job-iteration/pull/431) - Use Arel to generate SQL that's type compatible for the
+  cursor pagination conditionals in ActiveRecord cursor. Previously, the cursor would coerce numeric ids to a string value 
+  (e.g.: `... AND id > '1'`)
 
 ## v1.4.1 (Sep 5, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,6 @@ Nil
 when generating position for cursor based on `:id` column (Rails 7.1 and above, where composite
 primary models are now supported). This ensures we grab the value of the id column, rather than a
 potentially composite primary key value.
-- [456](https://github.com/Shopify/job-iteration/pull/431) - Use Arel to generate SQL that's type compatible for the
-  cursor pagination conditionals in ActiveRecord cursor. Previously, the cursor would coerce numeric ids to a string value 
-  (e.g.: `... AND id > '1'`)
 
 ## v1.4.1 (Sep 5, 2023)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 PATH
   remote: .
   specs:
-    job-iteration (1.5.0)
+    job-iteration (1.5.1)
       activejob (>= 5.2)
 
 GEM

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.5.0"
+  VERSION = "1.5.1"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -106,40 +106,6 @@ module LoggingHelpers
   end
 end
 
-module ActiveRecordHelpers
-  def assert_sql(*patterns_to_match, &block)
-    captured_queries = []
-    assert_nothing_raised do
-      ActiveSupport::Notifications.subscribed(
-        ->(_name, _start_time, _end_time, _subscriber_id, payload) { captured_queries << payload[:sql] },
-        "sql.active_record",
-        &block
-      )
-    end
-
-    failed_patterns = []
-    patterns_to_match.each do |pattern|
-      failed_check = captured_queries.none? do |sql|
-        case pattern
-        when Regexp
-          sql.match?(pattern)
-        when String
-          sql == pattern
-        else
-          raise ArgumentError, "#assert_sql encountered an unknown matcher #{pattern.inspect}"
-        end
-      end
-      failed_patterns << pattern if failed_check
-    end
-    queries = captured_queries.empty? ? "" : "\nQueries:\n  #{captured_queries.join("\n  ")}"
-    assert_predicate(
-      failed_patterns,
-      :empty?,
-      "Query pattern(s) #{failed_patterns.map(&:inspect).join(", ")} not found.#{queries}",
-    )
-  end
-end
-
 JobIteration.logger = Logger.new(IO::NULL)
 ActiveJob::Base.logger = Logger.new(IO::NULL)
 

--- a/test/unit/active_record_enumerator_test.rb
+++ b/test/unit/active_record_enumerator_test.rb
@@ -4,8 +4,6 @@ require "test_helper"
 
 module JobIteration
   class ActiveRecordEnumeratorTest < IterationUnitTest
-    include ActiveRecordHelpers
-
     SQL_TIME_FORMAT = "%Y-%m-%d %H:%M:%S.%N"
     test "#records yields every record with their cursor position" do
       enum = build_enumerator.records
@@ -132,13 +130,6 @@ module JobIteration
         enum.records.each { |record, _cursor| order_names << record.name }
 
         assert_equal(["Red hat", "Blue jeans", "Yellow socks"], order_names)
-      end
-    end
-
-    test "enumerator paginates using integer conditionals for primary key when no columns are defined" do
-      enum = build_enumerator(relation: Product.all, batch_size: 1).records
-      assert_sql(/`products`\.`id` > 1/) do
-        enum.take(2)
       end
     end
 


### PR DESCRIPTION
Reverts Shopify/job-iteration#456

#456 introduced a bug in the following code path:
https://github.com/Shopify/job-iteration/blob/e17e2caba6f9c4d7014f13cfb3fb636454377ef3/lib/job-iteration/active_record_cursor.rb#L37

when `relation.reorder(*<array_of_arels>)` is invoked, implicitly a `to_s` is called on each Arel, which expands them to `"table.column"` and ActiveRecord prepends `table` again, leading to a clause like:
```sql
 ORDER BY `products`.`products.created_at`, products`.`products.id`
```

instead of:
```sql
 ORDER BY products.created_at, products.id
```
which was the previous behaviour.