### PR TITLE
Remove skipped tests for StatsD metrics which don't exist

### DIFF
--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -608,32 +608,6 @@ module JobIteration
       assert_equal([params, params], ParamsIterationJob.records_performed)
     end
 
-    def test_emits_metric_when_interrupted
-      skip("statsd is coming")
-      iterate_exact_times(2.times)
-
-      push(ActiveRecordIterationJob)
-
-      assert_statsd_increment("background_queue.iteration.interrupted") do
-        work_one_job
-      end
-    end
-
-    def test_emits_metric_when_resumed
-      skip("statsd is coming")
-      iterate_exact_times(2.times)
-
-      push(ActiveRecordIterationJob)
-
-      assert_no_statsd_calls("background_queue.iteration.resumed") do
-        work_one_job
-      end
-
-      assert_statsd_increment("background_queue.iteration.resumed") do
-        work_one_job
-      end
-    end
-
     def test_log_completion_data
       push(ParamsIterationJob, times: 3)
 


### PR DESCRIPTION
Job-iteration is instrumented through ActiveSupport::Notification, which allows users to choose their own metrics backend. I don't expect us to add a built-in StatsD integration any time soon, so these 6-year old tests can be deleted for now.