### PR TITLE
Add interruption adapter for Solid Queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Main (unreleased)
 
 - [464](https://github.com/Shopify/job-iteration/pull/464) - Add interruption adapter for [GoodJob](https://github.com/bensheldon/good_job).
+- [505](https://github.com/Shopify/job-iteration/pull/505) - Add interruption adapter for [Solid Queue](https://github.com/rails/solid_queue).
 
 ## v1.5.1 (May 29,2024)
 - [483](https://github.com/Shopify/job-iteration/pull/483) - Reverts [#456 Use Arel instead of String for AR Enumerator conditionals](https://github.com/Shopify/job-iteration/pull/456)

--- a/lib/job-iteration/interruption_adapters.rb
+++ b/lib/job-iteration/interruption_adapters.rb
@@ -4,7 +4,7 @@ require_relative "interruption_adapters/null_adapter"
 
 module JobIteration
   module InterruptionAdapters
-    BUNDLED_ADAPTERS = [:good_job, :resque, :sidekiq].freeze # @api private
+    BUNDLED_ADAPTERS = [:good_job, :resque, :sidekiq, :solid_queue].freeze # @api private
 
     class << self
       # Returns adapter for specified name.

--- a/lib/job-iteration/interruption_adapters/solid_queue_adapter.rb
+++ b/lib/job-iteration/interruption_adapters/solid_queue_adapter.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+begin
+  require "solid_queue"
+rescue LoadError
+  # SolidQueue is not available, no need to load the adapter
+  return
+end
+
+begin
+  # SolidQueue.on_worker_stop was introduced in SolidQueue 0.7.1
+  gem("solid_queue", ">= 0.7.1")
+rescue Gem::LoadError
+  warn("job-iteration's interruption adapter for SolidQueue requires SolidQueue 0.7.1 or newer")
+  return
+end
+
+module JobIteration
+  module InterruptionAdapters
+    module SolidQueueAdapter
+      class << self
+        attr_accessor :stopping
+
+        def call
+          stopping
+        end
+      end
+
+      SolidQueue.on_worker_stop do
+        SolidQueueAdapter.stopping = true
+      end
+    end
+
+    register(:solid_queue, SolidQueueAdapter)
+  end
+end

--- a/test/integration/interruption_adapters_test.rb
+++ b/test/integration/interruption_adapters_test.rb
@@ -14,7 +14,7 @@ class InterruptionAdaptersTest < ActiveSupport::TestCase
     RUBY
     _stdout, stderr, status = run_ruby(ruby)
 
-    assert_predicate(status, :success?)
+    assert_predicate(status, :success?, "Errors: #{stderr}")
     refute_match(/No interruption adapter is registered for :resque/, stderr)
   end
 
@@ -28,7 +28,7 @@ class InterruptionAdaptersTest < ActiveSupport::TestCase
     RUBY
     _stdout, stderr, status = run_ruby(ruby)
 
-    assert_predicate(status, :success?)
+    assert_predicate(status, :success?, "Errors: #{stderr}")
     assert_match(/No interruption adapter is registered for :sidekiq/, stderr)
   end
 
@@ -36,15 +36,17 @@ class InterruptionAdaptersTest < ActiveSupport::TestCase
     ruby = <<~RUBY
       require 'bundler/setup'
       require 'job-iteration'
-      # The adapter for GoodJob cannot be easily tested at the moment.
-      addapters_to_test = JobIteration::InterruptionAdapters::BUNDLED_ADAPTERS - [:good_job]
-      addapters_to_test.each do |name|
+
+      adapters_to_exclude = [:good_job, :solid_queue] # These require a Rails app to be loaded
+      adapters_to_test = JobIteration::InterruptionAdapters::BUNDLED_ADAPTERS - adapters_to_exclude
+
+      adapters_to_test.each do |name|
         JobIteration::InterruptionAdapters.lookup(name)
       end
     RUBY
     _stdout, stderr, status = run_ruby(ruby)
 
-    assert_predicate(status, :success?)
+    assert_predicate(status, :success?, "Errors: #{stderr}")
     refute_match(/No interruption adapter is registered for/, stderr)
   end
 


### PR DESCRIPTION
Resolves https://github.com/Shopify/job-iteration/issues/496

This PR adds an interruption adapter for [Solid Queue](https://github.com/rails/solid_queue). This will be the default Active Job back-end starting in Rails 8, so it's important that job-iteration works with it out of the box.

We can't test the loading properly, because even requiring `solid_queue` fails if we don't have `::Rails::Engine` and `ActiveModel` loaded.

TODO:
- [x] Rebase once https://github.com/Shopify/job-iteration/pull/504 merges
- [x] Manual test in a Rails app with Solid Queue