### PR TITLE
Release job-iteration v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Main (unreleased)
 
+Nil
+
+## v1.6.0 (Sep 24, 2024)
+
+### Features
+
 - [464](https://github.com/Shopify/job-iteration/pull/464) - Add interruption adapter for [GoodJob](https://github.com/bensheldon/good_job).
 - [505](https://github.com/Shopify/job-iteration/pull/505) - Add interruption adapter for [Solid Queue](https://github.com/rails/solid_queue).
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    job-iteration (1.5.1)
+    job-iteration (1.6.0)
       activejob (>= 5.2)
 
 GEM

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.5.1"
+  VERSION = "1.6.0"
 end


### PR DESCRIPTION
Two new interruption adapters feels like a good enough reason to cut a release.