### PR TITLE
Enable CSV Batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Main (unreleased)
 
-Nil
+- Added CSV batching functionality to EnumeratorBuilder with `build_csv_enumerator_on_batches` method and `csv_on_batches` alias.
 
 ## v1.6.0 (Sep 24, 2024)
 
@@ -29,7 +29,7 @@ when generating position for cursor based on `:id` column (Rails 7.1 and above, 
 primary models are now supported). This ensures we grab the value of the id column, rather than a
 potentially composite primary key value.
 - [456](https://github.com/Shopify/job-iteration/pull/431) - Use Arel to generate SQL that's type compatible for the
-  cursor pagination conditionals in ActiveRecord cursor. Previously, the cursor would coerce numeric ids to a string value 
+  cursor pagination conditionals in ActiveRecord cursor. Previously, the cursor would coerce numeric ids to a string value
   (e.g.: `... AND id > '1'`)
 
 ## v1.4.1 (Sep 5, 2023)

--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -144,6 +144,10 @@ module JobIteration
       CsvEnumerator.new(enumerable).rows(cursor: cursor)
     end
 
+    def build_csv_enumerator_on_batches(enumerable, cursor:, batch_size: 100)
+      CsvEnumerator.new(enumerable).batches(cursor: cursor, batch_size: batch_size)
+    end
+
     # Builds Enumerator for nested iteration.
     #
     # @param enums [Array<Proc>] an Array of Procs, each should return an Enumerator.
@@ -186,6 +190,7 @@ module JobIteration
     alias_method :active_record_on_batch_relations, :build_active_record_enumerator_on_batch_relations
     alias_method :throttle, :build_throttle_enumerator
     alias_method :csv, :build_csv_enumerator
+    alias_method :csv_on_batches, :build_csv_enumerator_on_batches
     alias_method :nested, :build_nested_enumerator
 
     private


### PR DESCRIPTION
I noticed that although CSV batching was implemented in [CsvEnumerator](https://github.com/Shopify/job-iteration/blob/d561d7e1a88c456689b1918f065609d264ec3c09/lib/job-iteration/csv_enumerator.rb#L41-L47), it was not implemented yet in `EnumeratorBuilder`.

I've gone ahead and added in `build_csv_enumerator_on_batches` with a default `batch_size` of `100` identical to the default used for active record batching along with an alias of `csv_on_batches`. 