### PR TITLE
Update CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
-        rails: ["5.2", "6.0", "6.1", "7.0", "7.1", "edge"]
+        rails: ["5.2", "6.0", "6.1", "7.0", "7.1", "7.2", "edge"]
         gemfile: [rails_gems]
         exclude:
           - ruby: "2.6"
@@ -23,21 +23,29 @@ jobs:
           - ruby: "2.6"
             rails: "7.1"
           - ruby: "2.6"
+            rails: "7.2"
+          - ruby: "2.6"
             rails: "edge"
           - ruby: "2.7"
             rails: "7.1"
+          - ruby: "2.7"
+            rails: "7.2"
           - ruby: "2.7"
             rails: "edge"
           - ruby: "3.0"
             rails: "5.2"
           - ruby: "3.0"
             rails: "7.1"
+          - ruby: "3.0"
+            rails: "7.2"
           - ruby: "3.0"
             rails: "edge"
           - ruby: "3.1"
             rails: "5.2"
           - ruby: "3.1"
             rails: "6.0"
+          - ruby: "3.1"
+            rails: "edge"
           - ruby: "3.2"
             rails: "5.2"
           - ruby: "3.2"


### PR DESCRIPTION
Rails 7.2 was released a little over a month ago, so it should be included in the CI matrix.
Now that Rails edge is Rails 8.0, it dropped support for Ruby 3.1, so I excluded that.

This is the current matrix: (+ means we test it):

| Rails \ Ruby  | 2.6 | 2.7 | 3.0 | 3.1 | 3.2 | 3.3 |
| ------------- | --- | --- | --- | --- | --- | --- |
| Rails 5.2     |  +  |  +  |  -  |  -  |  -  |  -  |
| Rails 6.0     |  +  |  +  |  +  |  -  |  -  |  -  |
| Rails 6.1     |  +  |  +  |  +  |  +  |  -  |  -  |
| Rails 7.0     |  -  |  +  |  +  |  +  |  +  |  +  |
| Rails 7.1     |  -  |  -  |  -  |  +  |  +  |  +  |
| Rails 7.2     |  -  |  -  |  -  |  +  |  +  |  +  |
| Rails edge    |  -  |  -  |  -  |  -  |  +  |  +  |