### PR TITLE
Correctly calculate size for array enumerator

### DIFF
--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -62,7 +62,7 @@ module JobIteration
           cursor + 1
         end
 
-      wrap(self, enumerable.each_with_index.drop(drop).to_enum { enumerable.size })
+      wrap(self, enumerable.each_with_index.drop(drop).to_enum { enumerable.size - drop })
     end
 
     # Builds Enumerator from Active Record Relation. Each Enumerator tick moves the cursor one row forward.


### PR DESCRIPTION
I don't think this is an actual problem for anybody, but if we're passing a size to `to_enum` it should be correct. Example:
```rb
array = ["a", "b", "c"]
drop = 1

current = array.each_with_index.drop(drop).to_enum { enumerable.size } 
current.size # 3 - wrong!
current.to_a.size # 2

new = array.each_with_index.drop(drop).to_enum { enumerable.size - drop } 
new.size # 2
```