### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         ports:
           - 6379:6379
     strategy:
+      fail-fast: false
       matrix:
         ruby: ["2.6", "2.7", "3.0", "3.1", "3.2", "3.3"]
         rails: ["5.2", "6.0", "6.1", "7.0", "7.1", "7.2", "edge"]

--- a/Gemfile
+++ b/Gemfile
@@ -37,3 +37,5 @@ gem "csv" # required for Ruby 3.4+
 
 # for unit testing optional sorbet support
 gem "sorbet-runtime"
+
+gem "logger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
       concurrent-ruby (~> 1.0)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
+    logger (1.6.5)
     method_source (1.1.0)
     minitest (5.24.0)
     mocha (2.7.1)
@@ -118,6 +119,7 @@ DEPENDENCIES
   globalid
   i18n
   job-iteration!
+  logger
   mocha
   mysql2!
   pry

--- a/test/integration/interruption_adapters_test.rb
+++ b/test/integration/interruption_adapters_test.rb
@@ -9,6 +9,7 @@ class InterruptionAdaptersTest < ActiveSupport::TestCase
       require 'bundler/setup'
       # Remove sidekiq, only resque will be left
       $LOAD_PATH.delete_if { |p| p =~ /sidekiq/ }
+      require 'logger'
       require 'job-iteration'
       JobIteration::InterruptionAdapters.lookup(:resque)
     RUBY
@@ -23,6 +24,7 @@ class InterruptionAdaptersTest < ActiveSupport::TestCase
       require 'bundler/setup'
       # Remove sidekiq, only resque will be left
       $LOAD_PATH.delete_if { |p| p =~ /sidekiq/ }
+      require 'logger'
       require 'job-iteration'
       JobIteration::InterruptionAdapters.lookup(:sidekiq)
     RUBY
@@ -35,6 +37,7 @@ class InterruptionAdaptersTest < ActiveSupport::TestCase
   test "loads all available interruption adapters" do
     ruby = <<~RUBY
       require 'bundler/setup'
+      require 'logger'
       require 'job-iteration'
 
       adapters_to_exclude = [:good_job, :solid_queue, :sqs] # These require a Rails app to be loaded

--- a/test/support/resque/Rakefile
+++ b/test/support/resque/Rakefile
@@ -4,8 +4,8 @@
 # $LOAD_PATH.unshift File.dirname(__FILE__) unless $LOAD_PATH.include?(File.dirname(__FILE__))
 require "resque/tasks"
 
+require "logger"
 require "job-iteration"
-require "active_job"
 require "i18n"
 
 require_relative "../jobs"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,13 +3,13 @@
 $LOAD_PATH.unshift(File.expand_path("../../lib", __FILE__))
 require "minitest/autorun"
 
+require "logger"
 require "job-iteration"
 require "job-iteration/test_helper"
 
 require "globalid"
 require "sidekiq"
 require "resque"
-require "active_job"
 require "active_record"
 require "pry"
 require "mocha/minitest"


### PR DESCRIPTION
`ActiveSupport::LoggerThreadSafeLevel` depends on `logger`, but doesn't require it explicitly prior to 7.1. In the real application, the `logger` is likely required by other components so this is not an issue. But for this gem's test setup, we need to require it explicitly.