### PR TITLE
Support keyword arguments in iteration jobs

### DIFF
--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -615,6 +615,12 @@ module JobIteration
       assert_equal([params, params], ParamsIterationJob.records_performed)
     end
 
+    def test_passes_kwargs_to_jobs_without_kwargs_in_build_enumerator
+      ParamsIterationJob.perform_later(times: 3)
+      work_one_job
+      assert_equal([{ times: 3 }, { times: 3 }, { times: 3 }], ParamsIterationJob.records_performed)
+    end
+
     def test_passes_kwargs_to_each_iteration
       KwargsIterationJob.perform_later(times: 3)
       work_one_job


### PR DESCRIPTION
It's now more common to have jobs that take keyword arguments, like `MyJob.perform_later(foo: "bar")`. But under the current implementation, `build_enumerator` can only take them as a hash argument instead of keyword arguments:

```ruby
def build_enumerator(params, cursor:)
  foo = params[:foo]
  # ...
end
```

This commit improves that by allowing keyword arguments to be passed to `build_enumerator` and `each_iteration` as:

```ruby
def build_enumerator(foo:, cursor:)
  # ...
end
```