### PR TITLE
Release job-iteration v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ nil
 
 nil
 
+## v1.9.0 (Feb 3, 2024)
+
+### Features
+
+- [533](https://github.com/Shopify/job-iteration/pull/533) Added a custom compiler for [Tapioca](https://github.com/Shopify/tapioca) that generates Sorbet types for `MyJob.perform_later` if `MyJob` includes `JobIteration::Iteration` and has defined a type for `build_enumerator`.
+
 ## v1.8.0 (Dec 10, 2024)
 
 ### Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    job-iteration (1.8.0)
+    job-iteration (1.9.0)
       activejob (>= 5.2)
 
 GEM

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.8.0"
+  VERSION = "1.9.0"
 end


### PR DESCRIPTION
Opted for a minor version, as the compiler could indirectly break CI for projects that use Sorbet type checking.