### PR TITLE
Remove unnecessary period from after Solid Queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Job-iteration currently supports the following queue adapters (in order of imple
 - [Resque](https://github.com/resque/resque)
 - [Sidekiq](https://github.com/sidekiq/sidekiq/)
 - [GoodJob](https://github.com/bensheldon/good_job)
-- [Solid Queue](https://github.com/rails/solid_queue).
+- [Solid Queue](https://github.com/rails/solid_queue)
 - [Amazon SQS](https://github.com/aws/aws-activejob-sqs-ruby)
 - [Delayed::Job](https://github.com/collectiveidea/delayed_job)
 


### PR DESCRIPTION
Simply removing an unnecessary `.` from after `Solid Queue`.

<img width="715" alt="Screenshot 2025-03-05 at 10 50 21" src="https://github.com/user-attachments/assets/5790df8f-2d4b-4d65-9610-9b428958b1c1" />