### PR TITLE
Release job-iteration v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Breaking Changes
 
-- [544](https://github.com/Shopify/job-iteration/pull/544) - Drop support for Ruby 2.6 and 2.7, and Rails 5.2 and 6.0. The minimum supported Ruby version is now 3.0, and the minimum supported Rails version is 6.1.
+nil
 
 ### Changes
 
@@ -10,13 +10,24 @@ nil
 
 ### Features
 
-- [547](https://github.com/Shopify/job-iteration/pull/547) Add interruption adapter for [DelayedJob](https://github.com/collectiveidea/delayed_job).
+nil
 
 ### Bug fixes
 
 nil
 
-## v1.9.0 (Feb 3, 2024)
+## v1.10.0 (Mar 20, 2025)
+
+### Breaking Changes
+
+- [544](https://github.com/Shopify/job-iteration/pull/544) - Drop support for Ruby 2.6 and 2.7, and Rails 5.2 and 6.0. The minimum supported Ruby version is now 3.0, and the minimum supported Rails version is 6.1.
+
+### Features
+
+- [547](https://github.com/Shopify/job-iteration/pull/547) Add interruption adapter for [DelayedJob](https://github.com/collectiveidea/delayed_job).
+- [556](https://github.com/Shopify/job-iteration/pull/556) Add support for generic job classes in the Tapioca Sorbet compiler.
+
+## v1.9.0 (Feb 3, 2025)
 
 ### Features
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    job-iteration (1.9.0)
+    job-iteration (1.10.0)
       activejob (>= 6.1)
 
 GEM

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.9.0"
+  VERSION = "1.10.0"
 end


### PR DESCRIPTION
Releasing a new version, as there have been some useful changes. I opted for a minor bump despite a breaking change, as the dropped dependencies are so old that they shouldn't affect the vast majority of users.