### PR TITLE
Introduce BatchDeletingEnumerator

### DIFF
--- a/lib/job-iteration/batch_deleting_enumerator.rb
+++ b/lib/job-iteration/batch_deleting_enumerator.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module JobIteration
+  class BatchDeletingEnumerator
+    include Enumerable
+
+    def initialize(relation, batch_size:)
+      @relation = relation
+      @batch_size = batch_size
+    end
+
+    def each(&block)
+      return to_enum unless block_given?
+
+      while (relation = next_batch)
+        yield relation, nil
+      end
+    end
+
+    private
+
+    def next_batch
+      primary_keys = @relation
+        .limit(@batch_size)
+        .order(@relation.klass.primary_key)
+        .pluck(*@relation.klass.primary_key)
+        .to_a
+
+      return if primary_keys.empty?
+
+      primary_keys
+    end
+
+    class << self
+      def delete_batch(relation, pk_values)
+        where_in(relation, relation.klass.primary_key => pk_values).delete_all
+      end
+
+      def where_in(relation, attrs_and_values)
+        attrs_and_values.reduce(relation) do |rel, (attrs, values)|
+          next rel.none if values.empty? || attrs.empty?
+
+          attrs = Array(attrs)
+          statement = "(#{attrs.join(", ")}) IN (#{(["(?)"] * values.size).join(", ")})"
+          sql = ActiveRecord::Base.sanitize_sql_array([statement, *values])
+          rel.where(sql)
+        end
+      end
+    end
+  end
+end

--- a/test/unit/batch_deleting_enumerator_test.rb
+++ b/test/unit/batch_deleting_enumerator_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "job-iteration/batch_deleting_enumerator"
+
+module JobIteration
+  class BatchDeletingEnumeratorTest < IterationUnitTest
+    test "#each yields batches of primary keys" do
+      enum = build_enumerator.each
+      products = Product.order(:id).take(4)
+
+      batch, _cursor = enum.next
+      assert_equal products.map(&:id).first(2), batch
+
+      JobIteration::BatchDeletingEnumerator.delete_batch(Product.all, batch)
+
+      batch, _cursor = enum.next
+      assert_equal products.map(&:id).last(2), batch
+    end
+
+    test "#each doesn't yield anything if the relation is empty" do
+      enum = build_enumerator(relation: Product.none)
+
+      assert_equal([], enum.to_a)
+    end
+
+    test "batch size is configurable" do
+      enum = build_enumerator(batch_size: 4)
+      products = Product.order(:id).take(4)
+
+      assert_equal([products.map(&:id), nil], enum.first)
+    end
+
+    test "delete_batch class method deletes records by primary key" do
+      products = Product.order(:id).take(2)
+      primary_keys = products.map(&:id)
+
+      BatchDeletingEnumerator.delete_batch(Product.all, primary_keys)
+
+      assert_equal 0, Product.where(id: primary_keys).count
+    end
+
+    private
+
+    def build_enumerator(relation: Product.all, batch_size: 2)
+      BatchDeletingEnumerator.new(
+        relation,
+        batch_size: batch_size,
+      )
+    end
+  end
+end


### PR DESCRIPTION
We have a very common use case at Shopify of cleaning up a set of records scoped to a relation (e.g. delete all of `Product.where(shop_id: 42)`. It's especially common with the [maintenance_tasks](https://github.com/shopify/maintenance_tasks) gem.

That relation may or not contain millions of rows.

It's possible to enumerate over those and batch delete them using existing `ActiveRecordEnumerator` but that quickly gets too complex for composite PK as we have to preserve a correct cursor over enumeration.

While in fact all we need to do is keep selecting and deleting up until there's no rows left.

This PR introduces such enumerator. It never returns a cursor and always keeps going.

Here's an example of an API:

```ruby
class ClearInventoryReservationsUnitsTask < ApplicationJob
  def build_enumerator(cursor:)
    BatchDeletingEnumerator.new(
      Product.where(shop_id: shop_id),
      batch_size: 1000
    )
  end

  def each_iteration(pk_values)
    BatchDeletingEnumerator.delete_batch(Inventory::ReservationUnit.all, pk_values)
  end
end
```

I've debated in my head whether the API should be more like:

```
class ClearInventoryReservationsUnitsTask < ApplicationJob
  def build_enumerator(cursor:)
    BatchDeletingEnumerator.new(
      Product.where(shop_id: shop_id),
      batch_size: 1000
    )
  end

  def each_iteration(_)
    # no-op, the enumerator executes DELETE on each iteration already
  end
end
```

But I've sticked with the first option as it's more explicit _and_ calling `.next` on enumerator does not produce side-effects.


cc @kirill-shopify 