### PR TITLE
Explicitly extend generic for DSL compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/job_iteration.rb
+++ b/lib/tapioca/dsl/compilers/job_iteration.rb
@@ -8,6 +8,7 @@ module Tapioca
     module Compilers
       class JobIteration < Compiler
         extend T::Sig
+        extend T::Generic
 
         ConstantType = type_member { { fixed: T.class_of(::JobIteration::Iteration) } }
         PARAM_TYPES_IN_ORDER = [


### PR DESCRIPTION
Add an explicit extend for `T::Generic` on the Tapioca DSL compiler since it depends on `type_member`. We are moving towards annotations using RBS comments, so the base `Compiler` class no longer extends `T::Generic`. Trying to update to the latest Tapioca reveals the problem.

Note: we can't upgrade Tapioca to latest in this gem because of the Ruby version constraints (Tapioca already dropped support for 3.0). However, I tested this manually with the latest one and the issue goes away.