### PR TITLE
Support conditional arguments in Sorbet compiler

### DIFF
--- a/lib/tapioca/dsl/compilers/job_iteration.rb
+++ b/lib/tapioca/dsl/compilers/job_iteration.rb
@@ -12,7 +12,7 @@ module Tapioca
 
         ConstantType = type_member { { fixed: T.class_of(::JobIteration::Iteration) } }
         PARAM_TYPES_IN_ORDER = [
-          RBI::Param,
+          RBI::ReqParam,
           RBI::OptParam,
           RBI::RestParam,
           RBI::KwParam,


### PR DESCRIPTION
Fixes https://github.com/Shopify/job-iteration/issues/591

When generating types for `build_enumerator` definitions with both required positional arguments and other types of arguments:

```ruby
def build_enumerator(user_id, foo_id = nil, cursor:)
```

The compiler failed with:

```
/Users/sander/.gem/ruby/3.3.5/gems/job-iteration-1.10.0/lib/tapioca/dsl/compilers/job_iteration.rb:60:in `sort_by': ArgumentError: comparison of NilClass with 1 failed (Parallel::UndumpableException)
	from /Users/sander/.gem/ruby/3.3.5/gems/job-iteration-1.10.0/lib/tapioca/dsl/compilers/job_iteration.rb:60:in `sort_by!'
	from /Users/sander/.gem/ruby/3.3.5/gems/job-iteration-1.10.0/lib/tapioca/dsl/compilers/job_iteration.rb:60:in `block in decorate'
	from /Users/sander/.gem/ruby/3.3.5/gems/tapioca-0.16.5/lib/tapioca/rbi_ext/model.rb:40:in `block in create_class'
	from <internal:kernel>:90:in `tap'
	from /Users/sander/.gem/ruby/3.3.5/gems/tapioca-0.16.5/lib/tapioca/rbi_ext/model.rb:39:in `create_class'
	from /Users/sander/.gem/ruby/3.3.5/gems/tapioca-0.16.5/lib/tapioca/rbi_ext/model.rb:16:in `create_path'
	from /Users/sander/.gem/ruby/3.3.5/gems/job-iteration-1.10.0/lib/tapioca/dsl/compilers/job_iteration.rb:27:in `decorate'
	from /Users/sander/.gem/ruby/3.3.5/gems/sorbet-runtime-0.5.11834/lib/types/private/methods/_methods.rb:279:in `bind_call'
	from /Users/sander/.gem/ruby/3.3.5/gems/sorbet-runtime-0.5.11834/lib/types/private/methods/_methods.rb:279:in `block in _on_method_added'
```

Looking at the parameter types and indices, this becomes clear:

```
types: [RBI::ReqParam, RBI::OptParam]
indexes: [nil, 1]
```

Because `RBI::ReqParam` is not in `PARAM_TYPES_IN_ORDER`, its index in that list is `nil`, and sorting it in a list with integers doesn't work. (The existing tests used either all mandatory positional arguments, or no mandatory positional arguments, so they didn't hit this case, and sorting a list with all `nil` elements does work.)

It turns out that `RBI::Param` is the superclass, and doesn't tend to occur as the concrete parameter type, so we can just replace it with `RBI::ReqParam` to fix it.

I also added some more test cases with optional parameters.