### PR TITLE
Clean up CSVEnumerator

### DIFF
--- a/lib/job-iteration/csv_enumerator.rb
+++ b/lib/job-iteration/csv_enumerator.rb
@@ -43,7 +43,10 @@ module JobIteration
         .each_slice(batch_size)
         .with_index
         .drop(count_of_processed_rows(cursor))
-        .to_enum { (count_of_rows_in_file.to_f / batch_size).ceil }
+        .to_enum do
+          num_rows = count_of_rows_in_file
+          num_rows.nil? ? nil : (num_rows.to_f / batch_size).ceil
+        end
     end
 
     private


### PR DESCRIPTION
This PR removes a work-around for Ruby 2.6 that is no longer necessary. It also ensures that calling `size` on a batch CSV enumerator returns `nil` if the file path cannot be found, instead of `0`.