### PR TITLE
Release job-iteration v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ nil
 
 nil
 
+## v1.11.0 (Jul 14, 2025)
+
+### Security fixes
+
+- [595](https://github.com/Shopify/job-iteration/pull/595) [CVE-2025-53623] Fixes a security issue in the `CSVEnumerator` where the filename was directly interpolated into a bash command.
+
+### Bug fixes
+
+- [590](https://github.com/Shopify/job-iteration/pull/590) Fix a compatibilty issue between the Sorbet DSL compiler and the latest Tapioca.
+- [593](https://github.com/Shopify/job-iteration/pull/593) Properly support required and optional positional arguments in the Sorbet DSL compiler.
+- [594](https://github.com/Shopify/job-iteration/pull/594) Clean up the size calculation in the `CSVEnumerator`.
+
 ## v1.10.0 (Mar 20, 2025)
 
 ### Breaking Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    job-iteration (1.10.0)
+    job-iteration (1.11.0)
       activejob (>= 6.1)
 
 GEM

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.10.0"
+  VERSION = "1.11.0"
 end


### PR DESCRIPTION
Add a change log for recent fixes, and bump the version to 1.11.0. I don't have a strong opinion on minor vs patch here.