### PR TITLE
fix: Make `EnumeratorBuilder#wrap` match documentation

### DIFF
--- a/test/unit/enumerator_builder_test.rb
+++ b/test/unit/enumerator_builder_test.rb
@@ -19,8 +19,7 @@ module JobIteration
     end
 
     test_builder_method(:wrap) do
-      builder = enumerator_builder
-      builder.wrap(builder, nil)
+      enumerator_builder.wrap(nil)
     end
 
     test_builder_method(:build_once_enumerator) do


### PR DESCRIPTION
As of #513 enums must be wrapped, and documentation shows examples like:

``` ruby
def build_enumerator(cursor:)
  enum_builder.wrap(
    some_enumerator
  )
end
```

However, `EnumeratorBuilder#wrap` is delegated to `@wrapper` which expects builder's instance as first argument. Thus, without this PR's patch we actually have to write code like:

``` ruby
def build_enumerator(cursor:)
  enum_builder.wrap(
    enum_builder,
    some_enumerator
  )
end
```