### PR TITLE
Fix Tapioca Compiler to Preserve Params for Empty FixedHash

### DIFF
--- a/lib/tapioca/dsl/compilers/job_iteration.rb
+++ b/lib/tapioca/dsl/compilers/job_iteration.rb
@@ -86,7 +86,7 @@ module Tapioca
         sig { params(typed_param: RBI::TypedParam, hash_type: T::Types::FixedHash).returns(T.any(RBI::TypedParam, T::Array[RBI::TypedParam])) }
         def expand_fixed_hash(typed_param, hash_type)
           if hash_type.types.empty?
-            create_opt_param(typed_param.param.name, type: "{}", default: "{}")
+            typed_param
           else
             hash_type.types.map do |key, value|
               if value.name.start_with?("T.nilable")

--- a/lib/tapioca/dsl/compilers/job_iteration.rb
+++ b/lib/tapioca/dsl/compilers/job_iteration.rb
@@ -38,13 +38,7 @@ module Tapioca
               fixed_hash_args = signature.arg_types.select { |arg_type| T::Types::FixedHash === arg_type[1] }.to_h
               expanded_parameters = parameters.flat_map do |typed_param|
                 if (hash_type = fixed_hash_args[typed_param.param.name.to_sym])
-                  hash_type.types.map do |key, value|
-                    if value.name.start_with?("T.nilable")
-                      create_kw_opt_param(key.to_s, type: value.to_s, default: "nil")
-                    else
-                      create_kw_param(key.to_s, type: value.to_s)
-                    end
-                  end
+                  expand_fixed_hash(typed_param, hash_type)
                 else
                   typed_param
                 end
@@ -88,6 +82,21 @@ module Tapioca
         end
 
         private
+
+        sig { params(typed_param: RBI::TypedParam, hash_type: T::Types::FixedHash).returns(T.any(RBI::TypedParam, T::Array[RBI::TypedParam])) }
+        def expand_fixed_hash(typed_param, hash_type)
+          if hash_type.types.empty?
+            create_opt_param(typed_param.param.name, type: "{}", default: "{}")
+          else
+            hash_type.types.map do |key, value|
+              if value.name.start_with?("T.nilable")
+                create_kw_opt_param(key.to_s, type: value.to_s, default: "nil")
+              else
+                create_kw_param(key.to_s, type: value.to_s)
+              end
+            end
+          end
+        end
 
         sig do
           params(

--- a/test/tapioca/dsl/compilers/job_iteration_test.rb
+++ b/test/tapioca/dsl/compilers/job_iteration_test.rb
@@ -565,19 +565,19 @@ module Tapioca
 
             class NotifyJob
               sig { params(params: {}).void }
-              def perform(params = {}); end
+              def perform(params); end
 
               class << self
             <% if rails_version(">= 7.0") %>
                 sig { params(params: {}, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(params = {}, &block); end
+                def perform_later(params, &block); end
             <% else %>
                 sig { params(params: {}).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(params = {}); end
+                def perform_later(params); end
             <% end %>
 
                 sig { params(params: {}).returns(T.any(NilClass, Exception)) }
-                def perform_now(params = {}); end
+                def perform_now(params); end
               end
             end
           RBI

--- a/test/tapioca/dsl/compilers/job_iteration_test.rb
+++ b/test/tapioca/dsl/compilers/job_iteration_test.rb
@@ -547,6 +547,85 @@ module Tapioca
           assert_equal(expected, rbi_for(:NotifyJob))
         end
 
+        def test_generates_correct_rbi_file_for_job_with_empty_fixed_hash_parameter
+          add_ruby_file("job.rb", <<~RUBY)
+            class NotifyJob < ActiveJob::Base
+              include JobIteration::Iteration
+
+              extend T::Sig
+              sig { params(params: {}, cursor: T.untyped).returns(T::Array[T.untyped]) }
+              def build_enumerator(params, cursor:)
+                # ...
+              end
+            end
+          RUBY
+
+          expected = template(<<~RBI)
+            # typed: strong
+
+            class NotifyJob
+              sig { params(params: {}).void }
+              def perform(params = {}); end
+
+              class << self
+            <% if rails_version(">= 7.0") %>
+                sig { params(params: {}, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
+                def perform_later(params = {}, &block); end
+            <% else %>
+                sig { params(params: {}).returns(T.any(NotifyJob, FalseClass)) }
+                def perform_later(params = {}); end
+            <% end %>
+
+                sig { params(params: {}).returns(T.any(NilClass, Exception)) }
+                def perform_now(params = {}); end
+              end
+            end
+          RBI
+          assert_equal(expected, rbi_for(:NotifyJob))
+        end
+
+        def test_generates_correct_rbi_file_for_job_with_all_nilable_fixed_hash_keys
+          add_ruby_file("job.rb", <<~RUBY)
+            class NotifyJob < ActiveJob::Base
+              include JobIteration::Iteration
+
+              extend T::Sig
+              sig do
+                params(
+                  params: { tag: T.nilable(String) },
+                  cursor: T.untyped
+                ).returns(T::Array[T.untyped])
+              end
+              def build_enumerator(params, cursor:)
+                # ...
+              end
+            end
+          RUBY
+
+          expected = template(<<~RBI)
+            # typed: strong
+
+            class NotifyJob
+              sig { params(tag: T.nilable(::String)).void }
+              def perform(tag: nil); end
+
+              class << self
+            <% if rails_version(">= 7.0") %>
+                sig { params(tag: T.nilable(::String), block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
+                def perform_later(tag: nil, &block); end
+            <% else %>
+                sig { params(tag: T.nilable(::String)).returns(T.any(NotifyJob, FalseClass)) }
+                def perform_later(tag: nil); end
+            <% end %>
+
+                sig { params(tag: T.nilable(::String)).returns(T.any(NilClass, Exception)) }
+                def perform_now(tag: nil); end
+              end
+            end
+          RBI
+          assert_equal(expected, rbi_for(:NotifyJob))
+        end
+
         def test_generates_correct_rbi_file_for_generic_jobs_with_one_generic_variable
           add_ruby_file("job.rb", <<~RUBY)
             class GenericJob < ActiveJob::Base


### PR DESCRIPTION
## Summary

  The tapioca DSL compiler for JobIteration explodes FixedHash types into keyword arguments on the generated `perform`/`perform_now`/`perform_later` methods. When the FixedHash is empty (`{}`),
  `hash_type.types.map` returns `[]`, and `flat_map` replaces the positional `params` parameter with nothing — generating zero-arg methods.

  This means a job like:

  ```ruby
  sig { params(params: {}, cursor: T.untyped).returns(T::Array[T.untyped]) }
  def build_enumerator(params, cursor:)

  # generates:

  # Before (broken)
  def perform; end
  def perform_now; end
  ```

  Any call site using perform_now({}) then fails with Sorbet error 7004 (too many arguments).

  ## Fix

When the FixedHash has zero keys, preserve the original positional parameter as-is instead of exploding to nothing:
  
```ruby                                                                                                                                                                                                       
  # After                                                                                                                                                                                                      
  sig { params(params: {}).void }
  def perform(params); end                                                                                                                                                                                       
  ```
                                                                                                                                                                                                                 
  The param stays required because the runtime method chain (`perform(*params) → build_enumerator(*arguments, cursor:)`) splats caller arguments directly — an RBI default does not exist at runtime, so `perform_now()` with zero args would raise `ArgumentError` in `build_enumerator`. Callers must pass `perform_now({})`.

Non-empty FixedHash explosion is unchanged — all existing behavior is preserved.

Also extracted `expand_fixed_hash` private method to keep block nesting within rubocop's 3-level limit (`Metrics/BlockNesting`).

## Tests

  - Added `test_generates_correct_rbi_file_for_job_with_empty_fixed_hash_parameter` — verifies the fix
  - Added `test_generates_correct_rbi_file_for_job_with_all_nilable_fixed_hash_keys` — verifies all-optional keys still explode to optional kwargs (no regression)