### PR TITLE
Bump tapioca to >= 0.19.1 to fix has_rest NoMethodError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ gem "csv" # required for Ruby 3.4+
 gem "mutex_m" # Required for Ruby 3.4+
 
 if ruby_version >= Gem::Version.new("3.2")
-  tapioca_version = ">= 0.17.9" # Fixes incompatibility with Sorbet >= 0.6.12698
+  tapioca_version = ">= 0.19.1" # Fixes incompatibility with Sorbet >= 0.6.13149 (has_rest removal)
   sorbet_version = ">= 0.6.12698"
 else
   tapioca_version = ">= 0.10.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,9 @@ GEM
       rubocop (~> 1.62)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    rubydex (0.1.0.beta13-arm64-darwin)
+    rubydex (0.1.0.beta13-x86_64-darwin)
+    rubydex (0.1.0.beta13-x86_64-linux)
     securerandom (0.4.1)
     sidekiq (8.0.10)
       connection_pool (>= 2.5.0)
@@ -223,17 +226,18 @@ GEM
       sorbet-static-and-runtime (>= 0.5.10187)
       thor (>= 0.19.2)
     stringio (3.1.8)
-    tapioca (0.17.9)
+    tapioca (0.19.1)
       benchmark
       bundler (>= 2.2.25)
       netrc (>= 0.11.0)
       parallel (>= 1.21.0)
       rbi (>= 0.3.7)
       require-hooks (>= 0.2.2)
-      sorbet-static-and-runtime (>= 0.5.11087)
+      rubydex (>= 0.1.0.beta10)
+      sorbet-static-and-runtime (>= 0.6.12698)
       spoom (>= 1.7.9)
       thor (>= 1.2.0)
-      yard-sorbet
+      tsort
     thor (1.4.0)
     tilt (2.6.1)
     timeout (0.4.4)
@@ -246,9 +250,6 @@ GEM
     uri (1.1.1)
     useragent (0.16.11)
     yard (0.9.37)
-    yard-sorbet (0.9.0)
-      sorbet-runtime
-      yard
     zeitwerk (2.7.3)
 
 PLATFORMS
@@ -276,7 +277,7 @@ DEPENDENCIES
   rubocop-shopify
   sidekiq (>= 8.0.9)
   sorbet-runtime (>= 0.6.12698)
-  tapioca (>= 0.17.9)
+  tapioca (>= 0.19.1)
   yard
 
 BUNDLED WITH


### PR DESCRIPTION
## Summary                                                                                                                                                                                                     
                                         
  `sorbet-runtime` 0.6.13149 (sorbet/sorbet#10177, April 20) removed the `has_rest` and `has_keyrest` accessor methods from `T::Private::Methods::Signature`. `tapioca` 0.18.0 still calls them in               
  `parameters_types_from_signature`, causing `NoMethodError` on Ruby 3.2+ CI where bundler resolves to the latest compatible versions.                                                                           
                                                                                                                                                                                                                 
  Fixed in tapioca 0.19.1 (Shopify/tapioca#2603) which replaced `signature.has_rest` with `signature.rest_type` truthiness checks.                                                                               
   
  ## Test plan
  
  - [x] Ruby 3.1 CI unaffected
  - [x] Ruby 3.2 CI passes (previously all sig-based tapioca compiler tests failed with `NoMethodError: undefined method 'has_rest'`)                                                                            
  - [x] Ruby 3.3+ CI unaffected
