### PR TITLE
Add parallel iteration scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ nil
 
 ### Features
 
-nil
+- [702](https://github.com/Shopify/job-iteration/pull/702) - Add support for parallel iteration with `enumerator_builder.parallel`. This enqueues multiple jobs, allowing you to split up the work across multiple instances.
 
 ### Bug fixes
 

--- a/dev.yml
+++ b/dev.yml
@@ -11,8 +11,12 @@ up:
   - redis
   - custom:
       name: Create Job Iteration database
-      meet: mysql -uroot -h $MYSQL_HOST -P $MYSQL_PORT -e "CREATE DATABASE job_iteration_test"
-      met?: mysql -uroot -h $MYSQL_HOST -P $MYSQL_PORT job_iteration_test -e "SELECT 1" &> /dev/null
+      meet: |
+        DB_NAME="job_iteration_test${SERVICE_NAMESPACE:+_$SERVICE_NAMESPACE}"
+        mysql -uroot -h $MYSQL_HOST -P $MYSQL_PORT -e "CREATE DATABASE IF NOT EXISTS \`$DB_NAME\`"
+      met?: |
+        DB_NAME="job_iteration_test${SERVICE_NAMESPACE:+_$SERVICE_NAMESPACE}"
+        mysql -uroot -h $MYSQL_HOST -P $MYSQL_PORT "$DB_NAME" -e "SELECT 1" &> /dev/null
 
 commands:
   test:

--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -5,6 +5,7 @@ require_relative "active_record_enumerator"
 require_relative "csv_enumerator"
 require_relative "throttle_enumerator"
 require_relative "nested_enumerator"
+require_relative "parallel_enumerator"
 require "forwardable"
 
 module JobIteration
@@ -185,6 +186,17 @@ module JobIteration
       wrap(self, enum)
     end
 
+    def build_parallel_enumerator(instances:, cursor:, &block)
+      unless instances.is_a?(Integer) && instances.positive?
+        raise ArgumentError, "instances must be a positive Integer"
+      end
+
+      return ParallelEnumerator::EnqueueJobs.new(instances) if cursor.nil?
+
+      enum = ParallelEnumerator.new(block, instances: instances, cursor: cursor).to_enum
+      wrap(self, enum)
+    end
+
     alias_method :once, :build_once_enumerator
     alias_method :times, :build_times_enumerator
     alias_method :array, :build_array_enumerator
@@ -195,6 +207,7 @@ module JobIteration
     alias_method :csv, :build_csv_enumerator
     alias_method :csv_on_batches, :build_csv_enumerator_on_batches
     alias_method :nested, :build_nested_enumerator
+    alias_method :parallel, :build_parallel_enumerator
 
     private
 

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -141,6 +141,14 @@ module JobIteration
         return
       end
 
+      if enumerator.is_a?(ParallelEnumerator::EnqueueJobs)
+        tags = instrumentation_tags.merge(instances: enumerator.instances)
+        ActiveSupport::Notifications.instrument("enqueue_parallel_jobs.iteration", tags) do
+          enumerator.enqueue_jobs(self)
+        end
+        return
+      end
+
       assert_enumerator!(enumerator)
 
       if executions == 1 && times_interrupted == 0

--- a/lib/job-iteration/log_subscriber.rb
+++ b/lib/job-iteration/log_subscriber.rb
@@ -19,6 +19,12 @@ module JobIteration
       end
     end
 
+    def enqueue_parallel_jobs(event)
+      info do
+        "[JobIteration::Iteration] Enqueued #{event.payload[:instances]} parallel jobs."
+      end
+    end
+
     def interrupted(event)
       info do
         "[JobIteration::Iteration] Interrupting and re-enqueueing the job " \

--- a/lib/job-iteration/parallel_enumerator.rb
+++ b/lib/job-iteration/parallel_enumerator.rb
@@ -1,0 +1,51 @@
+# typed: true
+# frozen_string_literal: true
+
+module JobIteration
+  # ParallelEnumerator allows you to parallelize iterations.
+  class ParallelEnumerator
+    class EnqueueError < StandardError; end
+
+    class EnqueueJobs
+      def initialize(instances)
+        @instances = instances
+      end
+
+      attr_reader :instances
+
+      def enqueue_jobs(job)
+        child_jobs = instances.times.map do |index|
+          job.class.new(*job.arguments).tap do |child_job|
+            child_job.cursor_position = { "instance" => index, "inner_cursor" => nil }
+
+            # Carry forward potential overrides from the parent job
+            child_job.queue_name = job.queue_name
+            child_job.priority = job.priority if job.priority
+          end
+        end
+
+        ActiveJob.perform_all_later(child_jobs)
+
+        unless child_jobs.all?(&:successfully_enqueued?)
+          failed_count = instances - child_jobs.count(&:successfully_enqueued?)
+          raise EnqueueError, "Failed to enqueue #{failed_count} out of #{instances} child jobs"
+        end
+      end
+    end
+
+    def initialize(block, instances:, cursor:)
+      @instance = cursor["instance"]
+      inner_cursor = cursor["inner_cursor"]
+      @inner_enum = block.call(@instance, instances, inner_cursor)
+    end
+
+    def to_enum
+      Enumerator.new(-> { @inner_enum.size }) do |yielder|
+        @inner_enum.each do |object_from_enumerator, cursor_from_enumerator|
+          parallel_cursor = { "instance" => @instance, "inner_cursor" => cursor_from_enumerator }
+          yielder.yield(object_from_enumerator, parallel_cursor)
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,10 +40,12 @@ end
 
 mysql_host = ENV.fetch("MYSQL_HOST") { "localhost" }
 mysql_port = ENV.fetch("MYSQL_PORT") { 3306 }
+service_namespace = ENV.fetch("SERVICE_NAMESPACE") { nil }
+db_name = "job_iteration_test#{service_namespace ? "_#{service_namespace}" : ""}"
 
 connection_config = {
   adapter: "mysql2",
-  database: "job_iteration_test",
+  database: db_name,
   username: "root",
   host: mysql_host,
   port: mysql_port,

--- a/test/unit/enumerator_builder_test.rb
+++ b/test/unit/enumerator_builder_test.rb
@@ -78,6 +78,15 @@ module JobIteration
       )
     end
 
+    test_builder_method(:build_parallel_enumerator) do
+      enumerator_builder.build_parallel_enumerator(
+        instances: 2,
+        cursor: { "instance" => 0, "inner_cursor" => nil },
+      ) do |_instance, _instances, inner_cursor|
+        enumerator_builder.build_array_enumerator([1, 2, 3], cursor: inner_cursor)
+      end
+    end
+
     # checks that all the non-alias methods were tested
     raise "methods not tested: #{methods.inspect}" unless methods.empty?
 

--- a/test/unit/parallel_enumerator_test.rb
+++ b/test/unit/parallel_enumerator_test.rb
@@ -1,0 +1,247 @@
+# typed: ignore
+# frozen_string_literal: true
+
+require "test_helper"
+
+module JobIteration
+  class ParallelEnumeratorTest < IterationUnitTest
+    INSTANCES = 3
+
+    class IterationParallelJob < ActiveJob::Base
+      include JobIteration::Iteration
+
+      cattr_accessor :iterations_performed, instance_accessor: false
+      self.iterations_performed = []
+
+      cattr_accessor :on_start_called, instance_accessor: false
+      self.on_start_called = 0
+
+      cattr_accessor :on_shutdown_called, instance_accessor: false
+      self.on_shutdown_called = 0
+
+      cattr_accessor :on_complete_called, instance_accessor: false
+      self.on_complete_called = 0
+
+      on_start do
+        self.class.on_start_called += 1
+      end
+
+      on_shutdown do
+        self.class.on_shutdown_called += 1
+      end
+
+      on_complete do
+        self.class.on_complete_called += 1
+      end
+
+      def build_enumerator(_params, cursor:)
+        enumerator_builder.parallel(instances: INSTANCES, cursor: cursor) do |instance, instances, inner_cursor|
+          records = (instance..9).step(instances).to_a
+          enumerator_builder.build_array_enumerator(records, cursor: inner_cursor)
+        end
+      end
+
+      def each_iteration(record, _params)
+        self.class.iterations_performed << record
+      end
+    end
+
+    setup do
+      IterationParallelJob.iterations_performed = []
+      IterationParallelJob.on_start_called = 0
+      IterationParallelJob.on_shutdown_called = 0
+      IterationParallelJob.on_complete_called = 0
+    end
+
+    test "build_parallel_enumerator raises ArgumentError when instances is not a positive Integer" do
+      [0, -1, nil, 3.5, "3"].each do |bad_value|
+        error = assert_raises(ArgumentError, "expected ArgumentError for instances: #{bad_value.inspect}") do
+          enumerator_builder.build_parallel_enumerator(instances: bad_value, cursor: nil) { |_, _, _| [] }
+        end
+        assert_equal("instances must be a positive Integer", error.message)
+      end
+    end
+
+    test "build_parallel_enumerator returns EnqueueJobs when cursor is nil" do
+      result = enumerator_builder.build_parallel_enumerator(instances: 3, cursor: nil) { |_, _, _| [] }
+      assert_instance_of(ParallelEnumerator::EnqueueJobs, result)
+    end
+
+    test "build_parallel_enumerator does not invoke the block when cursor is nil" do
+      called = false
+      enumerator_builder.build_parallel_enumerator(instances: 3, cursor: nil) do |_, _, _|
+        called = true
+        []
+      end
+      refute(called)
+    end
+
+    test "build_parallel_enumerator returns a wrapped enumerator when cursor is given" do
+      enum = enumerator_builder.build_parallel_enumerator(
+        instances: 2,
+        cursor: { "instance" => 0, "inner_cursor" => nil },
+      ) do |_, _, inner_cursor|
+        enumerator_builder.build_array_enumerator([1, 2, 3], cursor: inner_cursor)
+      end
+
+      assert_kind_of(EnumeratorBuilder::Wrapper, enum)
+    end
+
+    test "ParallelEnumerator passes instance, instances, and inner_cursor to the block" do
+      received = []
+      block = ->(instance, instances, inner_cursor) {
+        received << [instance, instances, inner_cursor]
+        [].each
+      }
+
+      ParallelEnumerator.new(block, instances: 4, cursor: { "instance" => 2, "inner_cursor" => "abc" })
+
+      assert_equal([[2, 4, "abc"]], received)
+    end
+
+    test "ParallelEnumerator yields each value with a parallel cursor wrapping the inner cursor" do
+      block = ->(_instance, _instances, inner_cursor) {
+        enumerator_builder.build_array_enumerator(["a", "b", "c"], cursor: inner_cursor)
+      }
+      enum = ParallelEnumerator.new(block, instances: 2, cursor: { "instance" => 1, "inner_cursor" => nil }).to_enum
+
+      yielded = enum.to_a
+
+      assert_equal(
+        [
+          ["a", { "instance" => 1, "inner_cursor" => 0 }],
+          ["b", { "instance" => 1, "inner_cursor" => 1 }],
+          ["c", { "instance" => 1, "inner_cursor" => 2 }],
+        ],
+        yielded,
+      )
+    end
+
+    test "ParallelEnumerator resumes iteration from the inner cursor" do
+      block = ->(_instance, _instances, inner_cursor) {
+        enumerator_builder.build_array_enumerator(["a", "b", "c"], cursor: inner_cursor)
+      }
+      enum = ParallelEnumerator.new(block, instances: 2, cursor: { "instance" => 0, "inner_cursor" => 0 }).to_enum
+
+      assert_equal(
+        [
+          ["b", { "instance" => 0, "inner_cursor" => 1 }],
+          ["c", { "instance" => 0, "inner_cursor" => 2 }],
+        ],
+        enum.to_a,
+      )
+    end
+
+    test "ParallelEnumerator size delegates to the inner enumerator" do
+      block = ->(_instance, _instances, inner_cursor) {
+        enumerator_builder.build_array_enumerator([1, 2, 3, 4, 5], cursor: inner_cursor)
+      }
+      enum = ParallelEnumerator.new(block, instances: 2, cursor: { "instance" => 0, "inner_cursor" => nil }).to_enum
+
+      assert_equal(5, enum.size)
+    end
+
+    test "iteration with parallel enumerator enqueues one job per instance when cursor is nil" do
+      IterationParallelJob.perform_now({})
+
+      enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs
+      assert_equal(INSTANCES, enqueued.size)
+
+      cursor_positions = enqueued.map { |job| job.fetch("cursor_position") }
+      assert_equal(
+        INSTANCES.times.map { |i| { "instance" => i, "inner_cursor" => nil } },
+        cursor_positions,
+      )
+    end
+
+    test "iteration with parallel enumerator enqueues jobs of the same class as the calling job" do
+      IterationParallelJob.perform_now({})
+
+      enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs
+      job_classes = enqueued.map { |job| job.fetch("job_class") }
+      assert_equal([IterationParallelJob.name] * INSTANCES, job_classes)
+    end
+
+    test "iteration with parallel enumerator forwards arguments to enqueued jobs" do
+      params = { "shop_id" => 42 }
+      IterationParallelJob.perform_now(params)
+
+      enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs
+      assert_equal(INSTANCES, enqueued.size)
+      enqueued.each do |job|
+        deserialized_arguments = ActiveJob::Arguments.deserialize(job.fetch("arguments"))
+        assert_equal([params], deserialized_arguments)
+      end
+    end
+
+    test "iteration with parallel enumerator forwards parent queue_name and priority overrides to enqueued jobs" do
+      job = IterationParallelJob.new({})
+      job.queue_name = "custom_queue"
+      job.priority = 10
+      job.perform_now
+
+      enqueued = ActiveJob::Base.queue_adapter.enqueued_jobs
+      assert_equal(INSTANCES, enqueued.size)
+      enqueued.each do |child|
+        assert_equal("custom_queue", child.fetch("queue_name"))
+        assert_equal(10, child.fetch("priority"))
+      end
+    end
+
+    test "iteration with parallel enumerator raises EnqueueError if any child job fails to enqueue" do
+      IterationParallelJob.any_instance.stubs(:successfully_enqueued?).returns(false)
+
+      assert_raises(ParallelEnumerator::EnqueueError) do
+        IterationParallelJob.perform_now({})
+      end
+    end
+
+    test "enqueue_parallel_jobs event is instrumented" do
+      called = false
+      callback = ->(_event, _started, _finished, _job_id, payload) {
+        called = true
+        assert_equal(IterationParallelJob.name, payload[:job_class])
+        assert_equal(INSTANCES, payload[:instances])
+      }
+      ActiveSupport::Notifications.subscribed(callback, "enqueue_parallel_jobs.iteration") do
+        IterationParallelJob.perform_now({})
+      end
+      assert(called)
+    end
+
+    test "iteration with parallel enumerator does not iterate or run iteration callbacks on the parent job" do
+      IterationParallelJob.perform_now({})
+
+      assert_empty(IterationParallelJob.iterations_performed)
+      assert_equal(0, IterationParallelJob.on_start_called)
+      assert_equal(0, IterationParallelJob.on_shutdown_called)
+      assert_equal(0, IterationParallelJob.on_complete_called)
+    end
+
+    test "iteration with parallel enumerator runs iteration callbacks on the child job" do
+      job = IterationParallelJob.new({})
+      job.cursor_position = { "instance" => 1, "inner_cursor" => nil }
+      job.perform_now
+
+      assert_equal([1, 4, 7], IterationParallelJob.iterations_performed)
+      assert_predicate(ActiveJob::Base.queue_adapter.enqueued_jobs, :empty?)
+      assert_equal(1, IterationParallelJob.on_start_called)
+      assert_equal(1, IterationParallelJob.on_shutdown_called)
+      assert_equal(1, IterationParallelJob.on_complete_called)
+    end
+
+    test "iteration with parallel enumerator updates cursor_position with the parallel cursor" do
+      job = IterationParallelJob.new({})
+      job.cursor_position = { "instance" => 2, "inner_cursor" => nil }
+      job.perform_now
+
+      assert_equal({ "instance" => 2, "inner_cursor" => 2 }, job.cursor_position)
+    end
+
+    private
+
+    def enumerator_builder
+      JobIteration::EnumeratorBuilder.new(nil)
+    end
+  end
+end


### PR DESCRIPTION
### What and why?

It's sometimes useful to iterate over a collection in parallel to speed up the completion of the work. This PR adds a primitive to enable that:

```ruby
def build_enumerator(cursor:)
  enumerator_builder.parallel(instances: 7, cursor: cursor) do |instance, total_instances, inner_cursor|
    enumerator_builder.active_record_on_records(
      Product.where("id % ? = ?", total_instances, instance),
      cursor: inner_cursor,
    )
  end
end
```

When this job is enqueued, it first runs with a `nil` cursor, causing it to enqueue the 5 child jobs, each with a cursor that looks like `{ instance: x, inner_cursor: nil }`, where `x` ranges from 0 to 4. When those jobs start, they build the inner enumerator and run as normal, except that the outer enumerator ensures that the cursor stays wrapped in this hash with `instance` and `inner_cursor`.

```mermaid
sequenceDiagram
      participant Parent as ParentJob
      participant Q as ActiveJob queue
      participant Child as ChildJob (instance i)

      activate Parent
      Parent->>Parent: build_enumerator(cursor: nil)
      Note over Parent: cursor is nil →<br/>user block NOT invoked
      Parent->>Parent: enqueue_jobs(self.class, arguments)
      Parent->>Q: perform_all_later([job_0..job_N-1])
      Note right of Parent: each child gets<br/>cursor_position =<br/>{instance: i, inner_cursor: nil}
      deactivate Parent

      Q->>Child: perform<br/>(cursor: {instance: i, inner_cursor: nil})
      activate Child
      Child->>Child: build_enumerator(cursor: {instance: i, ...})
      Note over Child: cursor non-nil →<br/>user block IS invoked,<br/>builds inner enum for instance i

      loop until done or interrupted
          Child->>Child: each_iteration(record)
          Note right of Child: cursor_position =<br/>{instance: i, inner_cursor: X}
      end

      alt interrupted
          Child->>Q: retry_job (carries current cursor)
          Q->>Child: perform<br/>(cursor: {instance: i, inner_cursor: X})
          Note over Child: cursor still non-nil →<br/>no re-fan-out,<br/>resumes from inner_cursor X
      else completes
          Note over Child: on_complete callback fires
      end
      deactivate Child
```

### Gotchas

- Callback behaviour could be unexpected, as the parent job runs no callbacks, and each child job runs the full set. So `on_start` means this particular instance is starting and `on_complete` means this particular instance is done iterating. There is no "all child jobs are done iterating" callback, as that would require some form of external synchronization.

### Follow-up

- I plan to add parallel versions of most existing enumerators that divvy up the work for you, so you can simply call `enumerator_builder.parallel_active_record_on_records(Product.all, instances: 5, cursor: cursor)`
- This needs documentation
