### PR TITLE
Release job-iteration v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ nil
 
 nil
 
+## v1.13.1 (Apr 28, 2026)
+
+### Bug fixes
+
+- [#699](https://github.com/Shopify/job-iteration/pull/699) - Fix tapioca compiler dropping empty FixedHash `{}` params.
+
 ## v1.13.0 (Mar 23, 2026)
 
 ### Breaking Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    job-iteration (1.13.0)
+    job-iteration (1.13.1)
       activejob (>= 7.0)
 
 GEM

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.13.0"
+  VERSION = "1.13.1"
 end


### PR DESCRIPTION
## What and why?

PR to cut a patch release that allows for correct tapioca compiler RBI generation for empty FixedHash {} params in https://github.com/Shopify/job-iteration/pull/699