### PR TITLE
Drop support for > 1 year EOL Rails 7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ["3.1", "3.2", "3.3", "3.4", "4.0"]
-        rails: ["7.0", "7.1", "7.2", "8.0", "8.1", "edge"]
+        rails: ["7.1", "7.2", "8.0", "8.1", "edge"]
         gemfile: [rails_gems]
         exclude:
           - ruby: "3.1"
@@ -31,10 +31,6 @@ jobs:
             rails: "edge"
           - ruby: "3.2"
             rails: "edge"
-          - ruby: "3.4"
-            rails: "7.0"
-          - ruby: "4.0"
-            rails: "7.0"
         include:
           - ruby: head
             rails: "edge"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
  
 ### Breaking Changes
 
-nil
+- [704](https://github.com/Shopify/job-iteration/pull/704) - Drop support for Rails 7.0. The minimum supported Rails version is now 7.1.
 
 ### Changes
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
   remote: .
   specs:
     job-iteration (1.13.1)
-      activejob (>= 7.0)
+      activejob (>= 7.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Job-iteration currently supports the following queue adapters (in order of imple
 It supports the following platforms:
 
 - Ruby 3.1 and later
-- Rails 7.0 and later
+- Rails 7.1 and later
 
 Support for older platforms that have reached end of life may occasionally be dropped if maintaining backwards compatibility is cumbersome.
 

--- a/job-iteration.gemspec
+++ b/job-iteration.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.metadata["changelog_uri"] = "https://github.com/Shopify/job-iteration/blob/main/CHANGELOG.md"
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
-  spec.add_dependency("activejob", ">= 7.0")
+  spec.add_dependency("activejob", ">= 7.1")
 end

--- a/lib/tapioca/dsl/compilers/job_iteration.rb
+++ b/lib/tapioca/dsl/compilers/job_iteration.rb
@@ -105,15 +105,11 @@ module Tapioca
           ).returns(T::Array[RBI::TypedParam])
         end
         def perform_later_parameters(parameters, returned_job_class)
-          if ::Gem::Requirement.new(">= 7.0").satisfied_by?(::ActiveJob.gem_version)
-            parameters.reject! { |typed_param| RBI::BlockParam === typed_param.param }
-            parameters + [create_block_param(
-              "block",
-              type: "T.nilable(T.proc.params(job: #{returned_job_class}).void)",
-            )]
-          else
-            parameters
-          end
+          parameters.reject! { |typed_param| RBI::BlockParam === typed_param.param }
+          parameters + [create_block_param(
+            "block",
+            type: "T.nilable(T.proc.params(job: #{returned_job_class}).void)",
+          )]
         end
 
         class << self

--- a/test/tapioca/dsl/compilers/job_iteration_test.rb
+++ b/test/tapioca/dsl/compilers/job_iteration_test.rb
@@ -70,13 +70,8 @@ module Tapioca
               def perform(user_id); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(user_id: T.untyped, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(user_id, &block); end
-            <% else %>
-                sig { params(user_id: T.untyped).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(user_id); end
-            <% end %>
 
                 sig { params(user_id: T.untyped).returns(T.any(NilClass, Exception)) }
                 def perform_now(user_id); end
@@ -105,13 +100,8 @@ module Tapioca
               def perform(user_id, foo_id = T.unsafe(nil)); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(user_id: T.untyped, foo_id: T.untyped, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(user_id, foo_id = T.unsafe(nil), &block); end
-            <% else %>
-                sig { params(user_id: T.untyped, foo_id: T.untyped).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(user_id, foo_id = T.unsafe(nil)); end
-            <% end %>
 
                 sig { params(user_id: T.untyped, foo_id: T.untyped).returns(T.any(NilClass, Exception)) }
                 def perform_now(user_id, foo_id = T.unsafe(nil)); end
@@ -140,13 +130,8 @@ module Tapioca
               def perform(user_id:, profile_id:); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(user_id: T.untyped, profile_id: T.untyped, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(user_id:, profile_id:, &block); end
-            <% else %>
-                sig { params(user_id: T.untyped, profile_id: T.untyped).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(user_id:, profile_id:); end
-            <% end %>
 
                 sig { params(user_id: T.untyped, profile_id: T.untyped).returns(T.any(NilClass, Exception)) }
                 def perform_now(user_id:, profile_id:); end
@@ -175,13 +160,8 @@ module Tapioca
               def perform(user_id:, profile_id: T.unsafe(nil)); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(user_id: T.untyped, profile_id: T.untyped, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(user_id:, profile_id: T.unsafe(nil), &block); end
-            <% else %>
-                sig { params(user_id: T.untyped, profile_id: T.untyped).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(user_id:, profile_id: T.unsafe(nil)); end
-            <% end %>
 
                 sig { params(user_id: T.untyped, profile_id: T.untyped).returns(T.any(NilClass, Exception)) }
                 def perform_now(user_id:, profile_id: T.unsafe(nil)); end
@@ -212,13 +192,8 @@ module Tapioca
               def perform(user_id); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(user_id: ::Integer, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(user_id, &block); end
-            <% else %>
-                sig { params(user_id: ::Integer).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(user_id); end
-            <% end %>
 
                 sig { params(user_id: ::Integer).returns(T.any(NilClass, Exception)) }
                 def perform_now(user_id); end
@@ -249,13 +224,8 @@ module Tapioca
               def perform(user_id, foo_id = T.unsafe(nil)); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(user_id: ::Integer, foo_id: T.nilable(::String), block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(user_id, foo_id = T.unsafe(nil), &block); end
-            <% else %>
-                sig { params(user_id: ::Integer, foo_id: T.nilable(::String)).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(user_id, foo_id = T.unsafe(nil)); end
-            <% end %>
 
                 sig { params(user_id: ::Integer, foo_id: T.nilable(::String)).returns(T.any(NilClass, Exception)) }
                 def perform_now(user_id, foo_id = T.unsafe(nil)); end
@@ -286,13 +256,8 @@ module Tapioca
               def perform(user_id:, profile_id:); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(user_id: ::Integer, profile_id: ::Integer, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(user_id:, profile_id:, &block); end
-            <% else %>
-                sig { params(user_id: ::Integer, profile_id: ::Integer).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(user_id:, profile_id:); end
-            <% end %>
 
                 sig { params(user_id: ::Integer, profile_id: ::Integer).returns(T.any(NilClass, Exception)) }
                 def perform_now(user_id:, profile_id:); end
@@ -323,13 +288,8 @@ module Tapioca
               def perform(user_id:, profile_id: T.unsafe(nil)); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(user_id: ::Integer, profile_id: T.nilable(::Integer), block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(user_id:, profile_id: T.unsafe(nil), &block); end
-            <% else %>
-                sig { params(user_id: ::Integer, profile_id: T.nilable(::Integer)).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(user_id:, profile_id: T.unsafe(nil)); end
-            <% end %>
 
                 sig { params(user_id: ::Integer, profile_id: T.nilable(::Integer)).returns(T.any(NilClass, Exception)) }
                 def perform_now(user_id:, profile_id: T.unsafe(nil)); end
@@ -360,13 +320,8 @@ module Tapioca
               def perform(user_id, name); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(user_id: ::Integer, name: ::String, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(user_id, name, &block); end
-            <% else %>
-                sig { params(user_id: ::Integer, name: ::String).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(user_id, name); end
-            <% end %>
 
                 sig { params(user_id: ::Integer, name: ::String).returns(T.any(NilClass, Exception)) }
                 def perform_now(user_id, name); end
@@ -399,13 +354,8 @@ module Tapioca
               def perform(user_id:, name:); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(user_id: ::Integer, name: ::String, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(user_id:, name:, &block); end
-            <% else %>
-                sig { params(user_id: ::Integer, name: ::String).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(user_id:, name:); end
-            <% end %>
 
                 sig { params(user_id: ::Integer, name: ::String).returns(T.any(NilClass, Exception)) }
                 def perform_now(user_id:, name:); end
@@ -438,13 +388,8 @@ module Tapioca
               def perform(name:, user_id: nil); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(name: ::String, user_id: T.nilable(::Integer), block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(name:, user_id: nil, &block); end
-            <% else %>
-                sig { params(name: ::String, user_id: T.nilable(::Integer)).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(name:, user_id: nil); end
-            <% end %>
 
                 sig { params(name: ::String, user_id: T.nilable(::Integer)).returns(T.any(NilClass, Exception)) }
                 def perform_now(name:, user_id: nil); end
@@ -483,13 +428,8 @@ module Tapioca
               def perform(shop_id:, resource_types:, locale:, metadata: nil); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(shop_id: ::Integer, resource_types: T::Array[::ResourceType], locale: ::Locale, metadata: T.nilable(::String), block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(shop_id:, resource_types:, locale:, metadata: nil, &block); end
-            <% else %>
-                sig { params(shop_id: ::Integer, resource_types: T::Array[::ResourceType], locale: ::Locale, metadata: T.nilable(::String)).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(shop_id:, resource_types:, locale:, metadata: nil); end
-            <% end %>
 
                 sig { params(shop_id: ::Integer, resource_types: T::Array[::ResourceType], locale: ::Locale, metadata: T.nilable(::String)).returns(T.any(NilClass, Exception)) }
                 def perform_now(shop_id:, resource_types:, locale:, metadata: nil); end
@@ -531,13 +471,8 @@ module Tapioca
               def perform(shop_ids:, profile_ids:, extension_ids:, foo:, bar:); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(shop_ids: T.any(::Integer, T::Array[::Integer]), profile_ids: T.any(::Integer, T::Array[::Integer]), extension_ids: T.any(::Integer, T::Array[::Integer]), foo: ::Symbol, bar: ::String, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(shop_ids:, profile_ids:, extension_ids:, foo:, bar:, &block); end
-            <% else %>
-                sig { params(shop_ids: T.any(::Integer, T::Array[::Integer]), profile_ids: T.any(::Integer, T::Array[::Integer]), extension_ids: T.any(::Integer, T::Array[::Integer]), foo: ::Symbol, bar: ::String).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(shop_ids:, profile_ids:, extension_ids:, foo:, bar:); end
-            <% end %>
 
                 sig { params(shop_ids: T.any(::Integer, T::Array[::Integer]), profile_ids: T.any(::Integer, T::Array[::Integer]), extension_ids: T.any(::Integer, T::Array[::Integer]), foo: ::Symbol, bar: ::String).returns(T.any(NilClass, Exception)) }
                 def perform_now(shop_ids:, profile_ids:, extension_ids:, foo:, bar:); end
@@ -568,13 +503,8 @@ module Tapioca
               def perform(params); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(params: {}, block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(params, &block); end
-            <% else %>
-                sig { params(params: {}).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(params); end
-            <% end %>
 
                 sig { params(params: {}).returns(T.any(NilClass, Exception)) }
                 def perform_now(params); end
@@ -610,13 +540,8 @@ module Tapioca
               def perform(tag: nil); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(tag: T.nilable(::String), block: T.nilable(T.proc.params(job: NotifyJob).void)).returns(T.any(NotifyJob, FalseClass)) }
                 def perform_later(tag: nil, &block); end
-            <% else %>
-                sig { params(tag: T.nilable(::String)).returns(T.any(NotifyJob, FalseClass)) }
-                def perform_later(tag: nil); end
-            <% end %>
 
                 sig { params(tag: T.nilable(::String)).returns(T.any(NilClass, Exception)) }
                 def perform_now(tag: nil); end
@@ -650,13 +575,8 @@ module Tapioca
               def perform(val:); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(val: Elem, block: T.nilable(T.proc.params(job: GenericJob[T.untyped]).void)).returns(T.any(GenericJob[T.untyped], FalseClass)) }
                 def perform_later(val:, &block); end
-            <% else %>
-                sig { params(val: Elem).returns(T.any(GenericJob[T.untyped], FalseClass)) }
-                def perform_later(val:); end
-            <% end %>
 
                 sig { params(val: Elem).returns(T.any(NilClass, Exception)) }
                 def perform_now(val:); end
@@ -691,13 +611,8 @@ module Tapioca
               def perform(val:, some_value:); end
 
               class << self
-            <% if rails_version(">= 7.0") %>
                 sig { params(val: Elem, some_value: SomeValue, block: T.nilable(T.proc.params(job: GenericJob[T.untyped, T.untyped]).void)).returns(T.any(GenericJob[T.untyped, T.untyped], FalseClass)) }
                 def perform_later(val:, some_value:, &block); end
-            <% else %>
-                sig { params(val: Elem, some_value: SomeValue).returns(T.any(GenericJob[T.untyped, T.untyped], FalseClass)) }
-                def perform_later(val:, some_value:); end
-            <% end %>
 
                 sig { params(val: Elem, some_value: SomeValue).returns(T.any(NilClass, Exception)) }
                 def perform_now(val:, some_value:); end


### PR DESCRIPTION
## What and why?

Rails 7.0 has not received security updates since [April 1, 2025](https://endoflife.date/rails), over a year ago.  Additionally, we'd like to use `ActiveJob.perform_all_later` in an [upcoming feature](https://github.com/Shopify/job-iteration/pull/702). This PR drops support for Rails 7.0. The new minimum supported Rails version is 7.1.