### PR TITLE
Add parallel array enumerator

### DIFF
--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -66,6 +66,23 @@ module JobIteration
       wrap(self, enumerable.each_with_index.drop(drop).to_enum { enumerable.size - drop })
     end
 
+    # Builds an Enumerator that iterates over a given array, across +instances+ parallel jobs.
+    #
+    # Child job i iterates over the slice of the array starting at
+    # index (array.size / instances * i).floor and ending at index (array.size / instances * (i + 1)).floor - 1.
+    def build_parallel_array_enumerator(array, instances:, cursor:)
+      unless array.is_a?(Array)
+        raise ArgumentError, "array must be an Array"
+      end
+
+      build_parallel_enumerator(instances: instances, cursor: cursor) do |instance, instances, inner_cursor|
+        slice_start = (array.size.to_f / instances * instance).floor
+        next_slice_start = (array.size.to_f / instances * (instance + 1)).floor
+        slice = array[slice_start...next_slice_start]
+        build_array_enumerator(slice, cursor: inner_cursor)
+      end
+    end
+
     # Builds Enumerator from Active Record Relation. Each Enumerator tick moves the cursor one row forward.
     #
     # +columns:+ argument is used to build the actual query for iteration. +columns+: defaults to primary key:
@@ -200,6 +217,7 @@ module JobIteration
     alias_method :once, :build_once_enumerator
     alias_method :times, :build_times_enumerator
     alias_method :array, :build_array_enumerator
+    alias_method :parallel_array, :build_parallel_array_enumerator
     alias_method :active_record_on_records, :build_active_record_enumerator_on_records
     alias_method :active_record_on_batches, :build_active_record_enumerator_on_batches
     alias_method :active_record_on_batch_relations, :build_active_record_enumerator_on_batch_relations

--- a/test/unit/enumerator_builder_test.rb
+++ b/test/unit/enumerator_builder_test.rb
@@ -87,6 +87,14 @@ module JobIteration
       end
     end
 
+    test_builder_method(:build_parallel_array_enumerator) do
+      enumerator_builder(wraps: 2).build_parallel_array_enumerator(
+        [1, 2, 3, 4],
+        instances: 2,
+        cursor: { "instance" => 0, "inner_cursor" => nil },
+      )
+    end
+
     # checks that all the non-alias methods were tested
     raise "methods not tested: #{methods.inspect}" unless methods.empty?
 

--- a/test/unit/parallel_enumerator_test.rb
+++ b/test/unit/parallel_enumerator_test.rb
@@ -238,10 +238,57 @@ module JobIteration
       assert_equal({ "instance" => 2, "inner_cursor" => 2 }, job.cursor_position)
     end
 
+    test "build_parallel_array_enumerator splits the array evenly when size divides by instances" do
+      array = (0...12).to_a
+
+      partitions = collect_array_partitions(array, instances: 3)
+
+      assert_equal([4, 4, 4], partitions.map(&:size))
+      assert_equal(array, partitions.flatten.sort)
+    end
+
+    test "build_parallel_array_enumerator covers the array with near-equal partitions when size does not divide by instances" do
+      array = (0...10).to_a
+
+      partitions = collect_array_partitions(array, instances: 3)
+
+      assert_equal(array, partitions.flatten.sort)
+      partition_sizes = partitions.map(&:size)
+      assert_operator(partition_sizes.max - partition_sizes.min, :<=, 1)
+    end
+
+    test "build_parallel_array_enumerator resumes from a partial inner_cursor" do
+      array = (0...10).to_a
+
+      enum = enumerator_builder.build_parallel_array_enumerator(
+        array,
+        instances: 3,
+        cursor: { "instance" => 1, "inner_cursor" => 0 },
+      )
+
+      assert_equal(
+        [
+          [4, { "instance" => 1, "inner_cursor" => 1 }],
+          [5, { "instance" => 1, "inner_cursor" => 2 }],
+        ],
+        enum.to_a,
+      )
+    end
+
     private
 
     def enumerator_builder
       JobIteration::EnumeratorBuilder.new(nil)
+    end
+
+    def collect_array_partitions(array, instances:)
+      (0...instances).map do |instance|
+        enumerator_builder.build_parallel_array_enumerator(
+          array,
+          instances: instances,
+          cursor: { "instance" => instance, "inner_cursor" => nil },
+        ).map { |record, _cursor| record }
+      end
     end
   end
 end


### PR DESCRIPTION
### What and why?

This PR adds a parallel array enumerator that builds on the foundation laid in https://github.com/Shopify/job-iteration/pull/702.

While it's not complex, getting the logic exactly right so each instance handles roughly the same number of elements and no elements are double-processed or missed is a bit tricky. That's why it's useful for this to live in the gem, instead of every user having to rebuild it.