### PR TITLE
Add parallel AR enumerator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ nil
 ### Features
 
 - [702](https://github.com/Shopify/job-iteration/pull/702) - Add support for parallel iteration with `enumerator_builder.parallel`. This enqueues multiple jobs, allowing you to split up the work across multiple instances.
+- [705](https://github.com/Shopify/job-iteration/pull/705) - Add support for parallel array iteration with `enumerator_builder.parallel_array`.
+- [706](https://github.com/Shopify/job-iteration/pull/706) - Add support for parallel Active Record relation iteration with `enumerator_builder.parallel_active_record_on_records` and `enumerator_builder.parallel_active_record_on_batches`.
 
 ### Bug fixes
 

--- a/lib/job-iteration/active_record_cursor.rb
+++ b/lib/job-iteration/active_record_cursor.rb
@@ -18,7 +18,7 @@ module JobIteration
       end
     end
 
-    def initialize(relation, columns = nil, position = nil)
+    def initialize(relation, columns, position, instance, instances)
       @columns = if columns
         Array(columns)
       else
@@ -35,6 +35,17 @@ module JobIteration
       end
 
       @base_relation = relation.reorder(@columns.join(","))
+
+      if instances.present?
+        pk = relation.primary_key
+        unless pk.is_a?(String) && relation.klass.column_for_attribute(pk).type == :integer
+          raise ArgumentError, "Parallel iteration requires a single integer primary key. " \
+            "For more complex cases, use the enumerator_builder.parallel primitive directly."
+        end
+
+        @base_relation = @base_relation.where("#{relation.table_name}.#{pk} % ? = ?", instances, instance)
+      end
+
       @reached_end = false
     end
 

--- a/lib/job-iteration/active_record_enumerator.rb
+++ b/lib/job-iteration/active_record_enumerator.rb
@@ -7,7 +7,7 @@ module JobIteration
   class ActiveRecordEnumerator
     SQL_DATETIME_WITH_NSEC = "%Y-%m-%d %H:%M:%S.%N"
 
-    def initialize(relation, columns: nil, batch_size: 100, timezone: nil, cursor: nil)
+    def initialize(relation, columns: nil, batch_size: 100, timezone: nil, cursor: nil, instance: nil, instances: nil)
       @relation = relation
       @batch_size = batch_size
       @timezone = timezone
@@ -17,6 +17,8 @@ module JobIteration
         Array(relation.primary_key).map { |pk| "#{relation.table_name}.#{pk}" }
       end
       @cursor = cursor
+      @instance = instance
+      @instances = instances
     end
 
     def records
@@ -39,7 +41,8 @@ module JobIteration
     end
 
     def size
-      @relation.count(:all)
+      full_size = @relation.count(:all)
+      @instances.present? ? full_size / @instances : full_size
     end
 
     private
@@ -61,7 +64,7 @@ module JobIteration
     end
 
     def finder_cursor
-      JobIteration::ActiveRecordCursor.new(@relation, @columns, @cursor)
+      JobIteration::ActiveRecordCursor.new(@relation, @columns, @cursor, @instance, @instances)
     end
 
     def column_value(record, attribute)

--- a/lib/job-iteration/enumerator_builder.rb
+++ b/lib/job-iteration/enumerator_builder.rb
@@ -121,6 +121,21 @@ module JobIteration
       wrap(self, enum)
     end
 
+    # Builds an Enumerator that iterates over a given Active Record Relation, across +instances+ parallel jobs.
+    #
+    # Child job i iterates over the records where the id is equal to (instance % instances).
+    def build_parallel_active_record_enumerator_on_records(scope, instances:, cursor:, **args)
+      build_parallel_enumerator(instances: instances, cursor: cursor) do |instance, instances, inner_cursor|
+        build_active_record_enumerator(
+          scope,
+          cursor: inner_cursor,
+          instances: instances,
+          instance: instance,
+          **args,
+        ).records
+      end
+    end
+
     # Builds Enumerator from Active Record Relation and enumerates on batches of records.
     # Each Enumerator tick moves the cursor +batch_size+ rows forward.
     #
@@ -134,6 +149,21 @@ module JobIteration
         **args,
       ).batches
       wrap(self, enum)
+    end
+
+    # Builds an Enumerator that iterates over a given Active Record Relation, across +instances+ parallel jobs, and enumerates on batches.
+    #
+    # Child job i iterates over the batches of records where the id is equal to (instance % instances).
+    def build_parallel_active_record_enumerator_on_batches(scope, instances:, cursor:, **args)
+      build_parallel_enumerator(instances: instances, cursor: cursor) do |instance, instances, inner_cursor|
+        build_active_record_enumerator(
+          scope,
+          cursor: inner_cursor,
+          instances: instances,
+          instance: instance,
+          **args,
+        ).batches
+      end
     end
 
     # Builds Enumerator from Active Record Relation and enumerates on batches, yielding Active Record Relations.
@@ -219,7 +249,9 @@ module JobIteration
     alias_method :array, :build_array_enumerator
     alias_method :parallel_array, :build_parallel_array_enumerator
     alias_method :active_record_on_records, :build_active_record_enumerator_on_records
+    alias_method :parallel_active_record_on_records, :build_parallel_active_record_enumerator_on_records
     alias_method :active_record_on_batches, :build_active_record_enumerator_on_batches
+    alias_method :parallel_active_record_on_batches, :build_parallel_active_record_enumerator_on_batches
     alias_method :active_record_on_batch_relations, :build_active_record_enumerator_on_batch_relations
     alias_method :throttle, :build_throttle_enumerator
     alias_method :csv, :build_csv_enumerator
@@ -229,14 +261,20 @@ module JobIteration
 
     private
 
-    def build_active_record_enumerator(scope, cursor:, **args)
+    def build_active_record_enumerator(scope, cursor:, instance: nil, instances: nil, **args)
       unless scope.is_a?(ActiveRecord::Relation)
         raise ArgumentError, "scope must be an ActiveRecord::Relation"
+      end
+
+      if (instance.nil? && instances.present?) || (instance.present? && instances.nil?)
+        raise ArgumentError, "instance and instances must both be provided or both be nil"
       end
 
       JobIteration::ActiveRecordEnumerator.new(
         scope,
         cursor: cursor,
+        instance: instance,
+        instances: instances,
         **args,
       )
     end

--- a/test/unit/active_record_enumerator_test.rb
+++ b/test/unit/active_record_enumerator_test.rb
@@ -196,15 +196,44 @@ module JobIteration
       end
     end
 
+    test "parallel partition covers the relation with near-equal partitions" do
+      ids = Product.pluck(:id).sort
+
+      partitions = (0...3).map do |instance|
+        enum = build_enumerator(instance: instance, instances: 3)
+        enum.records.map { |record, _cursor| record.id }
+      end
+
+      assert_equal(ids, partitions.flatten.sort)
+      partition_sizes = partitions.map(&:size)
+      assert_operator(partition_sizes.max - partition_sizes.min, :<=, 1)
+    end
+
+    test "parallel partition raises ArgumentError for non-integer primary key" do
+      Product.stubs(:column_for_attribute).returns(stub(type: :string))
+
+      enum = build_enumerator(instance: 0, instances: 3)
+      error = assert_raises(ArgumentError) { enum.records.first }
+      assert_match(/integer primary key/, error.message)
+    end
+
+    test "parallel partition raises ArgumentError for composite primary key" do
+      enum = build_enumerator(relation: TravelRoute.all, instance: 0, instances: 3)
+      error = assert_raises(ArgumentError) { enum.records.first }
+      assert_match(/integer primary key/, error.message)
+    end
+
     private
 
-    def build_enumerator(relation: Product.all, batch_size: 2, timezone: nil, columns: nil, cursor: nil)
+    def build_enumerator(relation: Product.all, batch_size: 2, timezone: nil, columns: nil, cursor: nil, instance: nil, instances: nil)
       JobIteration::ActiveRecordEnumerator.new(
         relation,
         batch_size: batch_size,
         timezone: timezone,
         columns: columns,
         cursor: cursor,
+        instance: instance,
+        instances: instances,
       )
     end
   end

--- a/test/unit/enumerator_builder_test.rb
+++ b/test/unit/enumerator_builder_test.rb
@@ -95,6 +95,22 @@ module JobIteration
       )
     end
 
+    test_builder_method(:build_parallel_active_record_enumerator_on_records) do
+      enumerator_builder.build_parallel_active_record_enumerator_on_records(
+        Product.all,
+        instances: 2,
+        cursor: { "instance" => 0, "inner_cursor" => nil },
+      )
+    end
+
+    test_builder_method(:build_parallel_active_record_enumerator_on_batches) do
+      enumerator_builder.build_parallel_active_record_enumerator_on_batches(
+        Product.all,
+        instances: 2,
+        cursor: { "instance" => 0, "inner_cursor" => nil },
+      )
+    end
+
     # checks that all the non-alias methods were tested
     raise "methods not tested: #{methods.inspect}" unless methods.empty?
 


### PR DESCRIPTION
### What and why?

This PR adds a parallel Active Record enumerator that builds on the foundation laid in https://github.com/Shopify/job-iteration/pull/702.

We add a single WHERE clause to the relation: `WHERE id % 5 = 1` (assuming `id` is the primary key, and this is instance 1 out of 5). This correctly divides the work between the instances, assuming the primary key values are somewhat well distributed. The clause is compatible with all common Rails databases, and composes cleanly with iterating over other `columns`. The query does perform worse, as each instance has to do a full PK scan and discard the non-matching rows. Total database load grows linearly with the number of instances.

Non-integer primary keys and composite primary keys are explicitly rejected. They could be supported with queries like `WHERE CRC32(uuid) % 5 = 1` or `WHERE CRC32(CONCAT_WS('|', pk_col1, pk_col2)) % 5 = 1`, but those functions differ between all the common DB backends (with SQLite not supporting them at all). Therefore it's cleaner to leave those trickier, less common cases to devs to implement manually with the `enumerator_builder.parallel` primitive.