### PR TITLE
Remove work-arounds for Rails < 7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,8 @@ gemspec
 ruby_version = Gem::Version.new(RUBY_VERSION)
 rails_version = ENV.fetch("RAILS_VERSION", "edge") == "edge" ? Gem::Version.new("8.2") : Gem::Version.new(ENV.fetch("RAILS_VERSION"))
 
-if ruby_version >= Gem::Version.new("3.2") && rails_version >= Gem::Version.new("7.1")
-  sidekiq_version = ">= 8.0.9" # Fixes incompatibility with connection_pool >= 3.0.0, but is not compatible with Rails 7.0
+if ruby_version >= Gem::Version.new("3.2")
+  sidekiq_version = ">= 8.0.9" # Fixes incompatibility with connection_pool >= 3.0.0
   connection_pool_version = ">= 3.0.0"
 else
   sidekiq_version = ">= 7.0.0"

--- a/gemfiles/rails_gems.gemfile
+++ b/gemfiles/rails_gems.gemfile
@@ -8,11 +8,3 @@ else                raise "Unsupported RAILS_VERSION: #{rails_version}"
 end
 
 eval_gemfile "../Gemfile"
-
-# https://github.com/rails/rails/pull/44083
-if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.1") &&
-    rails_version != "edge" && Gem::Version.new(rails_version) < Gem::Version.new("7")
-  gem "net-imap", require: false
-  gem "net-pop", require: false
-  gem "net-smtp", require: false
-end

--- a/lib/job-iteration/active_record_batch_enumerator.rb
+++ b/lib/job-iteration/active_record_batch_enumerator.rb
@@ -66,10 +66,6 @@ module JobIteration
       pkey = @column_mgr.primary_key
       pkey_values = primary_key_values
 
-      # If the primary key is only composed of a single column, simplify the
-      # query. This keeps us compatible with Rails prior to 7.1 where composite
-      # primary keys were introduced along with the syntax that allows you to
-      # query for multi-column values.
       if pkey.size <= 1
         pkey = pkey.first
         pkey_values = pkey_values.map(&:first)

--- a/lib/job-iteration/active_record_cursor.rb
+++ b/lib/job-iteration/active_record_cursor.rb
@@ -56,7 +56,7 @@ module JobIteration
       self.position = @columns.map do |column|
         method = column.to_s.split(".").last
 
-        if ActiveRecord.version >= Gem::Version.new("7.1.0.alpha") && method == "id"
+        if method == "id"
           record.id_value
         else
           record.send(method.to_sym)

--- a/lib/job-iteration/railtie.rb
+++ b/lib/job-iteration/railtie.rb
@@ -5,8 +5,7 @@ return unless defined?(Rails::Railtie)
 module JobIteration
   class Railtie < Rails::Railtie
     initializer "job_iteration.register_deprecator" do |app|
-      # app.deprecators was added in Rails 7.1
-      app.deprecators[:job_iteration] = JobIteration::Deprecation if app.respond_to?(:deprecators)
+      app.deprecators[:job_iteration] = JobIteration::Deprecation
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -126,12 +126,6 @@ module ActiveSupport
     def skip_until_version(version)
       skip("Deferred until version #{version}") if Gem::Version.new(JobIteration::VERSION) < Gem::Version.new(version)
     end
-
-    def skip_until_active_record_version(version)
-      return if ActiveRecord.version >= Gem::Version.new(version)
-
-      skip("Deferred until ActiveRecord version #{version}")
-    end
   end
 end
 

--- a/test/unit/active_record_batch_enumerator_test.rb
+++ b/test/unit/active_record_batch_enumerator_test.rb
@@ -172,7 +172,6 @@ module JobIteration
     end
 
     test "(composite primary key) #each yields batches as relation with the last record's cursor position" do
-      skip_until_active_record_version("7.1")
       seed_orders!
 
       enum = build_enumerator(relation: Order.all)
@@ -186,7 +185,6 @@ module JobIteration
     end
 
     test "(composite primary key) columns without a primary key column yields cursors without the unspecified value" do
-      skip_until_active_record_version("7.1")
       seed_orders!
 
       enum = build_enumerator(relation: Order.all, columns: [:name, :shop_id])
@@ -197,7 +195,6 @@ module JobIteration
     end
 
     test "(composite primary key) cursor can be used to resume on multiple columns" do
-      skip_until_active_record_version("7.1")
       seed_orders!
 
       enum = build_enumerator(relation: Order.all, columns: [:name, :id])
@@ -214,8 +211,6 @@ module JobIteration
     end
 
     test "(composite primary key) columns missing primary key column still queries for primary key values" do
-      skip_until_active_record_version("7.1")
-
       queries = track_queries do
         enum = build_enumerator(relation: Order.all, columns: [:name])
         enum.first
@@ -224,8 +219,6 @@ module JobIteration
     end
 
     test "(composite primary key) columns with only one primary key column still queries for all primary key values" do
-      skip_until_active_record_version("7.1")
-
       queries = track_queries do
         enum = build_enumerator(relation: Order.all, columns: ["orders.id", :name])
         enum.first
@@ -234,8 +227,6 @@ module JobIteration
     end
 
     test "(composite primary key) columns configured with primary key only queries primary key columns once" do
-      skip_until_active_record_version("7.1")
-
       queries = track_queries do
         enum = build_enumerator(relation: Order.all, columns: [:name, :id, "orders.shop_id"])
         enum.first
@@ -244,7 +235,6 @@ module JobIteration
     end
 
     test "(composite primary key) one query performed per batch, plus an additional one for the empty cursor" do
-      skip_until_active_record_version("7.1")
       seed_orders!
 
       enum = build_enumerator(relation: Order.all)

--- a/test/unit/active_record_enumerator_test.rb
+++ b/test/unit/active_record_enumerator_test.rb
@@ -168,32 +168,30 @@ module JobIteration
       assert_equal(10, enum.size)
     end
 
-    if ActiveRecord.version >= Gem::Version.new("7.1.0.alpha")
-      test "enumerator for a relation with a composite primary key" do
-        TravelRoute.create!(origin: "A", destination: "B")
-        TravelRoute.create!(origin: "A", destination: "C")
-        TravelRoute.create!(origin: "B", destination: "A")
+    test "enumerator for a relation with a composite primary key" do
+      TravelRoute.create!(origin: "A", destination: "B")
+      TravelRoute.create!(origin: "A", destination: "C")
+      TravelRoute.create!(origin: "B", destination: "A")
 
-        enum = build_enumerator(relation: TravelRoute.all, batch_size: 2)
+      enum = build_enumerator(relation: TravelRoute.all, batch_size: 2)
 
-        cursors = []
-        enum.records.each { |_record, cursor| cursors << cursor }
+      cursors = []
+      enum.records.each { |_record, cursor| cursors << cursor }
 
-        assert_equal([["A", "B"], ["A", "C"], ["B", "A"]], cursors)
-      end
+      assert_equal([["A", "B"], ["A", "C"], ["B", "A"]], cursors)
+    end
 
-      test "enumerator for a relation with a composite primary key using :id" do
-        Order.create!(name: "Yellow socks", shop_id: 3)
-        Order.create!(name: "Red hat", shop_id: 1)
-        Order.create!(name: "Blue jeans", shop_id: 1)
+    test "enumerator for a relation with a composite primary key using :id" do
+      Order.create!(name: "Yellow socks", shop_id: 3)
+      Order.create!(name: "Red hat", shop_id: 1)
+      Order.create!(name: "Blue jeans", shop_id: 1)
 
-        enum = build_enumerator(relation: Order.all, batch_size: 2)
+      enum = build_enumerator(relation: Order.all, batch_size: 2)
 
-        order_names = []
-        enum.records.each { |record, _cursor| order_names << record.name }
+      order_names = []
+      enum.records.each { |record, _cursor| order_names << record.name }
 
-        assert_equal(["Red hat", "Blue jeans", "Yellow socks"], order_names)
-      end
+      assert_equal(["Red hat", "Blue jeans", "Yellow socks"], order_names)
     end
 
     private


### PR DESCRIPTION
### What and why?

We dropped support for Rails 7.0 in https://github.com/Shopify/job-iteration/pull/704, but still had a bunch of work-arounds in the code. This PR cleans those up.