### PR TITLE
Release job-iteration v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,25 @@
  
 ### Breaking Changes
 
-- [704](https://github.com/Shopify/job-iteration/pull/704) - Drop support for Rails 7.0. The minimum supported Rails version is now 7.1.
+nil
 
 ### Changes
 
 nil
+
+### Features
+
+nil
+
+### Bug fixes
+
+nil
+
+## v1.14.0 (May 14, 2026)
+
+### Breaking Changes
+
+- [704](https://github.com/Shopify/job-iteration/pull/704) - Drop support for Rails 7.0. The minimum supported Rails version is now 7.1.
 
 ### Features
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    job-iteration (1.13.1)
+    job-iteration (1.14.0)
       activejob (>= 7.1)
 
 GEM

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.13.1"
+  VERSION = "1.14.0"
 end


### PR DESCRIPTION
Cut a minor release for the new parallel enumeration feature.

Documentation will follow soon with https://github.com/Shopify/job-iteration/pull/710