### PR TITLE
Support keyword arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ nil
 
 ### Features
 
-nil
+- Add support for keyword arguments in `build_enumerator` and `each_iteration` while preserving positional params Hash compatibility for existing jobs. This compatibility path is transitional; migrate jobs away from positional params Hash signatures paired with `perform_later(keyword: value)`.
 
 ### Bug fixes
 

--- a/guides/argument-semantics.md
+++ b/guides/argument-semantics.md
@@ -56,21 +56,17 @@ ArgumentativeJob.perform_later(_arg1 = "One", _arg2 = "Two", _arg3 = "Three")
 
 ### Jobs with keyword arguments
 
-Jobs with keyword arguments will have the keyword arguments available to both `build_enumerator` and `each_iteration`, but these arguments come packaged into a Hash in both cases. You will need to `fetch` or `[]` your parameter from the `Hash` you get passed in:
+Jobs with keyword arguments can declare those keyword arguments directly on both `build_enumerator` and `each_iteration`:
 
 ```ruby
 class ParameterizedJob < ActiveJob::Base
   include JobIteration::Iteration
 
-  def build_enumerator(kwargs, cursor:)
-    name = kwargs.fetch(:name)
-    email = kwargs.fetch(:email)
+  def build_enumerator(name:, email:, cursor:)
     # ...
   end
 
-  def each_iteration(object_yielded_from_enumerator, kwargs)
-    name = kwargs.fetch(:name)
-    email = kwargs.fetch(:email)
+  def each_iteration(object_yielded_from_enumerator, name:, email:)
     # ...
   end
 end
@@ -82,37 +78,27 @@ To enqueue the job:
 ParameterizedJob.perform_later(name: "Jane", email: "jane@host.example")
 ```
 
-Note that you cannot use `ruby2_keywords` at present, and the keyword arguments syntax is not supported in `each_iteration` / `build_enumerator`.
+The `cursor:` keyword argument on `build_enumerator` is reserved for `job-iteration`; do not pass a job argument named `cursor` when using keyword arguments.
 
-### Jobs with both positional and keyword arguments
-
-Jobs with keyword arguments will have the keyword arguments available to both `build_enumerator` and `each_iteration`, but these arguments come packaged into a Hash in both cases. You will need to `fetch` or `[]` your parameter from the `Hash` you get passed in. Positional arguments get passed first and "unsplatted" (not combined into an array), the `Hash` containing keyword arguments comes after:
+For compatibility with existing jobs, keyword arguments are still passed as a positional params Hash after any positional arguments when `build_enumerator` and `each_iteration` do not declare keyword arguments (other than `cursor` for `build_enumerator`). This compatibility path is transitional and will be removed in a future release; prefer declaring keyword arguments directly instead of combining a positional params Hash with `perform_later(keyword: value)`:
 
 ```ruby
-class HighlyConfigurableGreetingJob < ActiveJob::Base
+class LegacyParameterizedJob < ActiveJob::Base
   include JobIteration::Iteration
 
-  def build_enumerator(subject_line, kwargs, cursor:)
-    name = kwargs.fetch(:sender_name)
-    email = kwargs.fetch(:sender_email)
+  def build_enumerator(params, cursor:)
+    name = params.fetch(:name)
+    email = params.fetch(:email)
     # ...
   end
 
-  def each_iteration(object_yielded_from_enumerator, subject_line, kwargs)
-    name = kwargs.fetch(:sender_name)
-    email = kwargs.fetch(:sender_email)
+  def each_iteration(object_yielded_from_enumerator, params)
+    name = params.fetch(:name)
+    email = params.fetch(:email)
     # ...
   end
 end
 ```
-
-To enqueue the job:
-
-```ruby
-HighlyConfigurableGreetingJob.perform_later(_subject_line = "Greetings everybody!", sender_name: "Jane", sender_email: "jane@host.example")
-```
-
-Note that you cannot use `ruby2_keywords` at present, and the keyword arguments syntax is not supported in `each_iteration` / `build_enumerator`.
 
 ### Returning (yielding) from enumerators
 

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -107,8 +107,8 @@ module JobIteration
       self.total_time = Float(job_data["total_time"] || 0.0)
     end
 
-    def perform(*params) # @private
-      interruptible_perform(*params)
+    def perform(...) # @private
+      interruptible_perform(...)
 
       nil
     end
@@ -128,12 +128,12 @@ module JobIteration
       JobIteration.enumerator_builder.new(self)
     end
 
-    def interruptible_perform(*arguments)
+    def interruptible_perform(*args, **kwargs)
       self.start_time = Time.now.utc
 
       enumerator = nil
       ActiveSupport::Notifications.instrument("build_enumerator.iteration", instrumentation_tags) do
-        enumerator = build_enumerator(*arguments, cursor: cursor_position)
+        enumerator = call_job_iteration_build_enumerator(args, kwargs)
       end
 
       unless enumerator
@@ -161,7 +161,7 @@ module JobIteration
       end
 
       completed = catch(:abort) do
-        iterate_with_enumerator(enumerator, arguments)
+        iterate_with_enumerator(enumerator, args, kwargs)
       end
 
       run_callbacks(:shutdown)
@@ -178,8 +178,7 @@ module JobIteration
       end
     end
 
-    def iterate_with_enumerator(enumerator, arguments)
-      arguments = arguments.dup.freeze
+    def iterate_with_enumerator(enumerator, args, kwargs)
       found_record = false
       @needs_reenqueue = false
 
@@ -191,7 +190,7 @@ module JobIteration
         ActiveSupport::Notifications.instrument("each_iteration.iteration", tags) do
           found_record = true
           run_callbacks(:iterate) do
-            each_iteration(object_from_enumerator, *arguments)
+            call_job_iteration_each_iteration(object_from_enumerator, args, kwargs)
           end
           self.cursor_position = cursor_from_enumerator
         end
@@ -213,6 +212,64 @@ module JobIteration
       true
     ensure
       adjust_total_time
+    end
+
+    def call_job_iteration_build_enumerator(args, kwargs)
+      positional_args, keyword_args = normalize_job_iteration_arguments(args, kwargs, :build_enumerator)
+
+      if keyword_args&.key?(:cursor)
+        raise ArgumentError, "The keyword argument `cursor` is reserved for the job iteration framework. " \
+          "Please remove `cursor` from the arguments passed to the job or rename it"
+      end
+
+      # `keyword_args || {}` because splatting `nil` raises on Ruby < 3.4; it only
+      # became a no-op in 3.4 (https://bugs.ruby-lang.org/issues/20064).
+      build_enumerator(*positional_args, **(keyword_args || {}), cursor: cursor_position)
+    end
+
+    def call_job_iteration_each_iteration(object_from_enumerator, args, kwargs)
+      positional_args, keyword_args = normalize_job_iteration_arguments(args, kwargs, :each_iteration)
+      # `keyword_args || {}` because splatting `nil` raises on Ruby < 3.4; it only
+      # became a no-op in 3.4 (https://bugs.ruby-lang.org/issues/20064).
+      each_iteration(object_from_enumerator, *positional_args, **(keyword_args || {}))
+    end
+
+    # Normalize Active Job kwargs for job-iteration dispatch. If the target method
+    # accepts job keyword parameters other than build_enumerator's reserved cursor:,
+    # keep kwargs separate so they can be splatted. Otherwise, append kwargs as a
+    # positional params Hash for transitional compatibility with existing jobs
+    # enqueued with keyword syntax.
+    #: (Array[top], Hash[Symbol, top], Symbol) -> [Array[top], Hash[Symbol, top]?]
+    def normalize_job_iteration_arguments(args, kwargs, method_name)
+      if kwargs.empty?
+        [args.dup.freeze, nil]
+      elsif job_has_keyword_parameters?(method_name)
+        [args.dup.freeze, kwargs.dup.freeze]
+      else
+        params_hash_args = args + [kwargs]
+        [params_hash_args.dup.freeze, nil]
+      end
+    end
+
+    #: (Symbol) -> bool
+    def job_has_keyword_parameters?(method_name)
+      @job_has_keyword_parameters ||= {}
+      return @job_has_keyword_parameters[method_name] if @job_has_keyword_parameters.key?(method_name)
+
+      @job_has_keyword_parameters[method_name] = method_parameters(method_name).any? do |type, name|
+        job_keyword_argument?(method_name, type, name)
+      end
+    end
+
+    def job_keyword_argument?(method_name, type, name)
+      # Match keyword parameters: double-splat (**kwargs), required (key:) or optional (key: default).
+      return false unless type == :keyrest || type == :keyreq || type == :key
+
+      # Ignore the `cursor:` argument, which is part of the `job-iteration`
+      # framework, and not a argument in the job's serialized argument list.
+      return false if method_name == :build_enumerator && name == :cursor
+
+      true
     end
 
     def reenqueue_iteration_job

--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -48,6 +48,122 @@ module JobIteration
       end
     end
 
+    class KwargsIterationJob < SimpleIterationJob
+      def build_enumerator(one_arg:, another_arg:, cursor:)
+        enumerator_builder.build_times_enumerator(2, cursor: cursor)
+      end
+
+      def each_iteration(item, one_arg:, another_arg:)
+        self.class.records_performed << [item, one_arg, another_arg]
+      end
+    end
+
+    class MixedArgumentsIterationJob < SimpleIterationJob
+      def build_enumerator(positional_arg, kwarg1:, kwarg2:, cursor:)
+        enumerator_builder.build_times_enumerator(2, cursor: cursor)
+      end
+
+      def each_iteration(item, positional_arg, kwarg1:, kwarg2:)
+        self.class.records_performed << [item, positional_arg, kwarg1, kwarg2]
+      end
+    end
+
+    class KeyrestIterationJob < SimpleIterationJob
+      def build_enumerator(cursor:, **_kwargs)
+        enumerator_builder.build_times_enumerator(2, cursor: cursor)
+      end
+
+      def each_iteration(item, **kwargs)
+        self.class.records_performed << [item, kwargs]
+      end
+    end
+
+    class PositionalOnlyIterationJob < SimpleIterationJob
+      def build_enumerator(cursor:)
+        enumerator_builder.build_times_enumerator(1, cursor: cursor)
+      end
+
+      def each_iteration(item)
+        self.class.records_performed << item
+      end
+    end
+
+    def test_supports_keyword_arguments
+      KwargsIterationJob.perform_later(one_arg: "foo", another_arg: "bar")
+      work_one_job
+      expected = [
+        [0, "foo", "bar"],
+        [1, "foo", "bar"],
+      ]
+      assert_equal(expected, KwargsIterationJob.records_performed)
+    end
+
+    def test_supports_mixed_arguments
+      MixedArgumentsIterationJob.perform_later("foo", kwarg1: "bar", kwarg2: "baz")
+      work_one_job
+      expected = [
+        [0, "foo", "bar", "baz"],
+        [1, "foo", "bar", "baz"],
+      ]
+      assert_equal(expected, MixedArgumentsIterationJob.records_performed)
+    end
+
+    def test_supports_keyword_arguments_after_interruption
+      iterate_exact_times(1.times)
+      KwargsIterationJob.perform_later(one_arg: "foo", another_arg: "bar")
+
+      work_one_job
+      assert_equal([[0, "foo", "bar"]], KwargsIterationJob.records_performed)
+
+      work_one_job
+      expected = [
+        [0, "foo", "bar"],
+        [1, "foo", "bar"],
+      ]
+      assert_equal(expected, KwargsIterationJob.records_performed)
+    end
+
+    def test_supports_mixed_arguments_after_interruption
+      iterate_exact_times(1.times)
+      MixedArgumentsIterationJob.perform_later("foo", kwarg1: "bar", kwarg2: "baz")
+
+      work_one_job
+      assert_equal([[0, "foo", "bar", "baz"]], MixedArgumentsIterationJob.records_performed)
+
+      work_one_job
+      expected = [
+        [0, "foo", "bar", "baz"],
+        [1, "foo", "bar", "baz"],
+      ]
+      assert_equal(expected, MixedArgumentsIterationJob.records_performed)
+    end
+
+    def test_supports_keyrest_arguments
+      KeyrestIterationJob.perform_later(one_arg: "foo", another_arg: "bar")
+      work_one_job
+      expected = [
+        [0, { one_arg: "foo", another_arg: "bar" }],
+        [1, { one_arg: "foo", another_arg: "bar" }],
+      ]
+      assert_equal(expected, KeyrestIterationJob.records_performed)
+    end
+
+    def test_supports_positional_only_each_iteration_without_keywords
+      PositionalOnlyIterationJob.perform_later
+      work_one_job
+      assert_equal([0], PositionalOnlyIterationJob.records_performed)
+    end
+
+    def test_rejects_reserved_cursor_keyword_argument
+      KwargsIterationJob.perform_later(one_arg: "foo", another_arg: "bar", cursor: "custom-cursor")
+
+      error = assert_raises(ArgumentError) do
+        work_one_job
+      end
+
+      assert_match(/keyword argument `cursor` is reserved/, error.message)
+    end
+
     class ParamsIterationJob < SimpleIterationJob
       def build_enumerator(params, cursor:)
         enumerator_builder.build_times_enumerator(params.fetch(:times, 2), cursor: cursor)
@@ -601,6 +717,13 @@ module JobIteration
     def test_passes_params_to_each_iteration
       params = { "walrus" => "best" }
       push(ParamsIterationJob, params)
+      work_one_job
+      assert_equal([params, params], ParamsIterationJob.records_performed)
+    end
+
+    def test_keeps_keyword_arguments_as_params_hash_when_methods_do_not_accept_keywords
+      params = { times: 2 }
+      ParamsIterationJob.perform_later(**params)
       work_one_job
       assert_equal([params, params], ParamsIterationJob.records_performed)
     end


### PR DESCRIPTION
## iteration jobs today

Support only one signature shape, a positional params hash and `cursor`:

```ruby
class IterationJob < ActiveJob::Base
  include JobIteration::Iteration

  def build_enumerator(params, cursor:)
    shop_id = params.fetch(:shop_id)
    # ...
  end
end

# all enqueue styles work
IterationJob.perform_later(shop_id: 1) # ruby2_keywords
IterationJob.perform_later({ shop_id: 1 }) # single positional hash
params = {} # some hash we can't statically validate :scary:
IterationJob.perform_later(params) # single positional hash
```

We want to support kwargs, more details on why in #714:

```ruby
class IterationKwargsJob < ActiveJob::Base
  include JobIteration::Iteration

  def build_enumerator(shop_id:, cursor:)
    # ...
  end
end

# only the ruby2_keywords enqueue style should work for kwargs signatures
IterationKwargsJob.perform_later(shop_id: 1) # ruby2_keywords

# should not be allowed for kwargs signatures
IterationKwargsJob.perform_later({ shop_id: 1 }) # single positional hash
params = {} # some hash we can't statically validate :scary:
IterationKwargsJob.perform_later(params) # single positional hash
```

### Implementation

- Uses Ruby argument forwarding for the public `perform(...)` wrapper.
- Carries forwarded Active Job keyword arguments explicitly through the iteration dispatch path instead of relying on `Hash.ruby2_keywords_hash` checks.
- Routes `build_enumerator` and `each_iteration` calls through dispatch helpers instead of directly splatting arguments.
- The dispatch helpers inspect the target method signature:
  - if the target method declares job keyword arguments, forwarded kwargs are passed with `**kwargs`;
  - if the target method does not declare keyword arguments, the Hash is left as a positional params argument for backwards compatibility.
- Rejects `cursor:` as a user-provided keyword argument for keyword-aware `build_enumerator` methods because `cursor:` is reserved by job-iteration.
- Updates the argument semantics guide and changelog to document kwargs support and the transitional params-hash compatibility path.

### Compatibility note

Existing jobs using `def build_enumerator(params, cursor:)` with `perform_later(keyword: value)` continue to work for now. That compatibility path is transitional; jobs should migrate to explicit keyword signatures before a future major release removes positional params-hash support for keyword-style enqueues.
