### PR TITLE
ci: add 5m timeout to build job to fail fast on hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Fail fast if a job hangs (e.g. an integration worker that never self-terminates),
+    # instead of burning the GitHub Actions default 360-minute timeout.
+    timeout-minutes: 5
     name: Ruby ${{ matrix.ruby }} | Rails ${{ matrix.rails }} | Gemfile ${{ matrix.gemfile }}
     continue-on-error: ${{ matrix.rails == 'edge' }}
     services:


### PR DESCRIPTION
tests matrix runs in under 1 minute, but there is no timeout set. Noticed when working on [kwargs support ](https://github.com/Shopify/job-iteration/actions/runs/26963101613/job/79558437147) when tests were infinitely looping.

<img width="1317" height="402" alt="image" src="https://github.com/user-attachments/assets/a8038cf2-c3e2-4b9d-b1bd-281838d8f5dd" />
