### PR TITLE
Release job-iteration v1.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,17 @@ nil
 
 ### Features
 
-- Add support for keyword arguments in `build_enumerator` and `each_iteration` while preserving positional params Hash compatibility for existing jobs. This compatibility path is transitional; migrate jobs away from positional params Hash signatures paired with `perform_later(keyword: value)`.
+nil
 
 ### Bug fixes
 
 nil
+
+## v1.15.0 (Jun 4, 2026)
+
+### Features
+
+- [715](https://github.com/Shopify/job-iteration/pull/715) - Add support for keyword arguments in `build_enumerator` and `each_iteration` while preserving positional params Hash compatibility for existing jobs. This compatibility path is transitional; migrate jobs away from positional params Hash signatures paired with `perform_later(keyword: value)`.
 
 ## v1.14.0 (May 14, 2026)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    job-iteration (1.14.0)
+    job-iteration (1.15.0)
       activejob (>= 7.1)
 
 GEM

--- a/lib/job-iteration/version.rb
+++ b/lib/job-iteration/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module JobIteration
-  VERSION = "1.14.0"
+  VERSION = "1.15.0"
 end


### PR DESCRIPTION
Cut a minor release for keyword arguments support(https://github.com/Shopify/job-iteration/pull/715)